### PR TITLE
WIP: Script to download Sentinel-1 RTC datacubes to Zarr stores

### DIFF
--- a/get_sentinel1rtc.py
+++ b/get_sentinel1rtc.py
@@ -1,0 +1,71 @@
+"""
+Script to retrieve Sentinel-1 Radiometrically Terrain Corrected (RTC) tiles.
+
+Based on:
+- https://gitlab.com/frontierdevelopmentlab/2022-us-sarchangedetection/deepslide/-/blob/main/notebooks/data_sentinel-1_rtc.ipynb
+- https://zen3geo.readthedocs.io/en/v0.6.2/stacking.html
+"""
+import os
+
+import numpy as np
+import planetary_computer
+import pystac_client
+import rasterio
+import stackstac
+import xarray as xr
+
+# %%
+# Uncomment the line below and set your Planetary Computer subscription key
+# os.environ["PC_SDK_SUBSCRIPTION_KEY"] = "abcdefghijklmnopqrstuvwxyz123456"
+
+# %%
+# Set up spatiotemporal query to get Sentinel-1 RTC data from STAC API
+query = dict(
+    bbox=[99.8, -0.24, 100.07, 0.15],  # West, South, East, North
+    datetime=["2022-01-25T00:00:00Z", "2022-03-25T23:59:59Z"],
+    collections=["sentinel-1-rtc"],
+)
+catalog = pystac_client.Client.open(
+    url="https://planetarycomputer.microsoft.com/api/stac/v1",
+    modifier=planetary_computer.sign_inplace,
+)
+search = catalog.search(**query)
+item_collection = search.item_collection()
+print(item_collection.items)
+
+
+# %%
+# Stack all Sentinel-1 scenes along the time dimension into an xarray.DataArray
+da_sen1: xr.DataArray = stackstac.stack(
+    items=item_collection,
+    assets=["vh", "vv"],  # SAR polarizations
+    epsg=32647,  # UTM Zone 47N
+    resolution=20,  # Spatial resolution of 20 metres
+    bounds_latlon=[99.933681, -0.009951, 100.065765, 0.147054],  # W, S, E, N
+    xy_coords="center",  # pixel centroid coords instead of topleft corner
+    resampling=rasterio.enums.Resampling.nearest,
+    dtype=np.float32,
+    fill_value=np.nan,
+)
+
+# %%
+# To fix TypeError: Invalid value for attr 'spec'
+da_sen1.attrs["spec"] = str(da_sen1.spec)
+
+# To fix ValueError: unable to infer dtype on variable None
+for key, val in da_sen1.coords.items():
+    if val.dtype == "object":
+        print("Deleting", key)
+        da_sen1 = da_sen1.drop_vars(names=key)
+
+# Create xarray.Dataset datacube with VH and VV channels from SAR
+da_vh: xr.DataArray = da_sen1.sel(band="vh", drop=True).rename("vh")
+da_vv: xr.DataArray = da_sen1.sel(band="vv", drop=True).rename("vv")
+ds_sen1: xr.Dataset = xr.merge(objects=[da_vh, da_vv], join="override")
+
+print(ds_sen1)
+
+# %%
+# Save to Zarr
+ds_sen1.to_zarr(store := "data/sen1rtc.zarr")
+print(f"Saved to {store}")


### PR DESCRIPTION
Quick script to get Sentinel-1 Radiometrically Terrain Corrected (RTC) data.

Tested to work on Planetary Computer:

[![Open on Planetary Computer](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FClay-foundation%2Fmodel&urlpath=lab%2Ftree%2Fdata/sentinel-1%2Fplaceholder.ipynb&branch=main)

TODO:
- [x] Initial script
  - Making a query to the Planetary Computer STAC API - https://planetarycomputer.microsoft.com/dataset/sentinel-1-rtc
  - Stack each STAC item with `stackstac`
  - Fixing some incompatible attribute types while saving VV and VH as separate data variables in an `xarray.Dataset`
  - Save the data into a Zarr store
- [ ] Allow configuration of spatiotemporal queries
- [ ] Implement async parallelization (may do in separate PR)

Will need to figure out how to connect this with Sentinel-2 work at #11.

References:
- https://gitlab.com/frontierdevelopmentlab/2022-us-sarchangedetection/deepslide/-/blob/main/notebooks/data_sentinel-1_rtc.ipynb
- https://zen3geo.readthedocs.io/en/v0.6.2/stacking.html