### PR TITLE
Setup GitHub Actions Continuous Integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+# This workflow will install Python dependencies and run tests on a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Test
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-22.04]
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      # Checkout current git repository
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # Install Micromamba with conda-forge dependencies
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@db1df3ba9e07ea86f759e98b575c002747e9e757 # v1.6.0
+        with:
+          environment-name: claymodel
+          environment-file: conda-lock.yml
+
+      # Run the unit tests
+      - name: Test with pytest
+        run: |
+            micromamba install python=${{ matrix.python-version }} pytest
+            python -m pytest --verbose src/tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Checkpoints and logs
+checkpoints/*.ckpt
+lightning_logs/
+wandb/
+logs/
+
+# Data files and folders
+data/**
+!data/**/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+
+# Sphinx documentation
+docs/_build/
+
+# DotEnv configuration
+.env
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# Mac OS-specific storage files
+.DS_Store

--- a/src/tests/test_trainer.py
+++ b/src/tests/test_trainer.py
@@ -1,0 +1,26 @@
+"""
+Tests for command-line interface to execute ChaBuDNet.
+
+Based on advanced usage of running LightningCLI from Python at
+https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli_advanced_3.html#run-from-python
+"""
+import pytest
+
+from trainer import cli_main
+
+
+# %%
+@pytest.mark.parametrize("subcommand", ["fit", "validate", "test"])
+def test_cli_main(subcommand, capsys):
+    """
+    Ensure that running `python trainer.py` works with the subcommands `fit`
+    and `validate`.
+    """
+    with pytest.raises(expected_exception=SystemExit, match="0"):
+        cli_main(args=[subcommand, "--print_config=skip_null"])
+
+    captured = capsys.readouterr()
+    assert "seed_everything:" in captured.out
+    assert "trainer:" in captured.out
+    assert "model:" in captured.out
+    assert "data:" in captured.out


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add Continuous Integration tests for every Pull Request and push to the `main` branch

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Added an integration test under `src/tests/test_datapipe.py` to ensure LightningCLI from #24 works
- Add GitHub Actions workflow in `.github/workflows/test.yml` which runs on Ubuntu-22.04 and Python 3.11
  - Uses https://github.com/mamba-org/setup-micromamba to install dependencies
  - Note that the `conda-lock.yml` lockfile is used, since `micromamba` support it! However, we're installing `pytest` separately instead of adding it to the `environment.yml` file.
- Also added a .gitignore file

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Install `pytest` and run `python -m pytest --verbose src/tests/` locally

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Based on https://github.com/developmentseed/chabud2023/pull/5
