### PR TITLE
Add pre-commit hooks with ruff formatter/linter rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+    - id: check-added-large-files
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.5
+  hooks:
+    - id: ruff  # Run the linter
+      args: [ --fix ]
+      types_or: [ python, pyi, jupyter ]
+    - id: ruff-format  # Run the formatter
+      types_or: [ python, pyi, jupyter ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
       types_or: [ python, pyi, jupyter ]
     - id: ruff-format  # Run the formatter
       types_or: [ python, pyi, jupyter ]
+
+# https://pre-commit.ci/#configuration
+ci:
+  autofix_prs: true
+  autoupdate_schedule: quarterly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.ruff.format]
+# https://docs.astral.sh/ruff/settings/#format
+line-ending = "lf"  # Use UNIX `\n` line endings for all files
+
+[tool.ruff.lint]
+# https://docs.astral.sh/ruff/rules/
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "NPY",  # numpy
+    "PL",   # pylint
+    "UP",   # pyupgrade
+    "W",    # pycodestyle warnings
+]

--- a/trainer.py
+++ b/trainer.py
@@ -9,7 +9,6 @@ References:
 - https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html
 - https://pytorch-lightning.medium.com/introducing-lightningcli-v2-supercharge-your-training-c070d43c7dd6
 """
-import torch
 from lightning.pytorch.cli import ArgsType, LightningCLI
 
 from src.datamodule import BaseDataModule

--- a/trainer.py
+++ b/trainer.py
@@ -34,6 +34,7 @@ def cli_main(
         trainer_defaults=trainer_defaults,
         args=args,
     )
+    return cli
 
 
 # %%


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add [pre-commit](https://github.com/pre-commit/pre-commit) hooks with [ruff](https://github.com/astral-sh/ruff) linter/formatter to enforce certain rules on Python scripts and Jupyter notebooks.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- [x] Add a `.pre-commit-config.yaml` file for standard pre-commit hooks
- [x] Add `pyproject.toml` configuration file for ruff formatter/linter rules
- [x] Configure [pre-commit-ci](https://pre-commit.ci) GitHub App

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Install `pre-commit` and run `pre-commit run --all-files` locally

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->

References:
- https://pre-commit.com/index.html#quick-start
- https://docs.astral.sh/ruff/tutorial/#getting-started
