### PR TITLE
Configure model checkpointing

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -11,6 +11,7 @@ References:
 """
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.cli import ArgsType, LightningCLI
+from lightning.pytorch.plugins.io import AsyncCheckpointIO
 
 from src.datamodule import GeoTIFFDataPipeModule
 from src.model_vit import ViTLitModule
@@ -34,6 +35,7 @@ def cli_main(
             ),
         ],
         "logger": False,
+        "plugins": [AsyncCheckpointIO()],
         "precision": "bf16-mixed",
     },
     args: ArgsType = None,

--- a/trainer.py
+++ b/trainer.py
@@ -9,6 +9,7 @@ References:
 - https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html
 - https://pytorch-lightning.medium.com/introducing-lightningcli-v2-supercharge-your-training-c070d43c7dd6
 """
+from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.cli import ArgsType, LightningCLI
 
 from src.datamodule import GeoTIFFDataPipeModule
@@ -19,7 +20,22 @@ from src.model_vit import ViTLitModule
 def cli_main(
     save_config_callback=None,
     seed_everything_default=42,
-    trainer_defaults: dict = {"logger": False, "precision": "bf16-mixed"},
+    trainer_defaults: dict = {
+        "callbacks": [
+            ModelCheckpoint(
+                # dirpath="checkpoints/",
+                auto_insert_metric_name=False,
+                filename="vit_epoch-{epoch:02d}_train_loss-{train/loss:.2f}",
+                monitor="train/loss",
+                mode="min",
+                save_last=True,
+                save_top_k=3,
+                save_weights_only=True,
+            ),
+        ],
+        "logger": False,
+        "precision": "bf16-mixed",
+    },
     args: ArgsType = None,
 ):
     """


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Configuring how model weights are saved to checkpoint (*.ckpt) files during training

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Using Lightning's [ModelCheckpoint](https://lightning.ai/docs/pytorch/2.1.0/api/lightning.pytorch.callbacks.ModelCheckpoint.html) callback with the following parameters:
  - auto_insert_metric_name=False
  - filename="vit_epoch-{epoch:02d}_train_loss-{train/loss:.2f}"
  - monitor="train/loss"
  - mode="min"
  - save_last=True
  - save_top_k=3
  - save_weights_only=True
- Added the [AsyncCheckpointIO](https://lightning.ai/docs/pytorch/2.1.0/api/lightning.pytorch.plugins.io.AsyncCheckpointIO.html) plugin to reduce the gap in time between epochs when a checkpoint is saved

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `python trainer.py fit --trainer.max_epochs=20` locally
- Extra configuration options can be found using `python trainer.py fit --trainer.callbacks.help=ModelCheckpoint`

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->

References:
- https://github.com/Lightning-AI/lightning/issues/11561