### PR TITLE
Generate embeddings via prediction loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,9 @@ To train the model for a hundred epochs:
 
     python trainer.py fit --trainer.max_epochs=100
 
+To generate embeddings from the pretrained model's encoder on one image:
+
+    python trainer.py predict --ckpt_path=checkpoints/last.ckpt --data.batch_size=1 --trainer.limit_predict_batches=1
+
 More options can be found using `python trainer.py fit --help`, or at the
 [LightningCLI docs](https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html).

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -103,3 +103,13 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
             batch_size=None,  # handled in datapipe already
             num_workers=self.num_workers,
         )
+
+    def predict_dataloader(self) -> torch.utils.data.DataLoader:
+        """
+        Loads the data used in the prediction loop.
+        """
+        return torch.utils.data.DataLoader(
+            dataset=self.datapipe_val,
+            batch_size=None,  # handled in datapipe already
+            num_workers=self.num_workers,
+        )

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -70,19 +70,31 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
             root=self.data_path, masks="*.tif", recursive=True, length=423
         )
 
-        # Step 2 - Split GeoTIFF chips into train/val sets (80%/20%)
-        # https://pytorch.org/data/0.7/generated/torchdata.datapipes.iter.RandomSplitter.html
-        dp_train, dp_val = dp_paths.random_split(
-            weights={"train": 0.8, "validation": 0.2}, total_length=423, seed=42
-        )
+        if stage == "fit":  # training/validation loop
+            # Step 2 - Split GeoTIFF chips into train/val sets (80%/20%)
+            # https://pytorch.org/data/0.7/generated/torchdata.datapipes.iter.RandomSplitter.html
+            dp_train, dp_val = dp_paths.random_split(
+                weights={"train": 0.8, "validation": 0.2}, total_length=423, seed=42
+            )
 
-        # Step 3 - Read GeoTIFF into numpy.ndarray, batch and convert to torch.Tensor
-        self.datapipe_train = (
-            dp_train.map(fn=_array_to_torch).batch(batch_size=self.batch_size).collate()
-        )
-        self.datapipe_val = (
-            dp_val.map(fn=_array_to_torch).batch(batch_size=self.batch_size).collate()
-        )
+            # Step 3 - Read GeoTIFF into numpy array, batch and convert to torch.Tensor
+            self.datapipe_train = (
+                dp_train.map(fn=_array_to_torch)
+                .batch(batch_size=self.batch_size)
+                .collate()
+            )
+            self.datapipe_val = (
+                dp_val.map(fn=_array_to_torch)
+                .batch(batch_size=self.batch_size)
+                .collate()
+            )
+
+        elif stage == "predict":  # prediction loop
+            self.datapipe_predict = (
+                dp_paths.map(fn=_array_to_torch)
+                .batch(batch_size=self.batch_size)
+                .collate()
+            )
 
     def train_dataloader(self) -> torch.utils.data.DataLoader:
         """
@@ -109,7 +121,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
         Loads the data used in the prediction loop.
         """
         return torch.utils.data.DataLoader(
-            dataset=self.datapipe_val,
+            dataset=self.datapipe_predict,
             batch_size=None,  # handled in datapipe already
             num_workers=self.num_workers,
         )

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -145,6 +145,7 @@ class ViTLitModule(L.LightningModule):
         assert embeddings.shape == torch.Size(
             [self.B, 65, 768]  # (batch_size, sequence_length, hidden_size)
         )
+        assert not torch.isnan(embeddings).any()  # ensure no NaNs in embedding
 
         # Save embeddings in npy format
         outfolder: str = f"{self.trainer.default_root_dir}/data/embeddings"

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -81,9 +81,6 @@ class ViTLitModule(L.LightningModule):
         outputs: dict = self.vit.base_model(x)
 
         self.B = x.shape[0]
-        assert outputs.last_hidden_state.shape == torch.Size([self.B, 17, 768])
-        assert outputs.ids_restore.shape == torch.Size([self.B, 64])
-        assert outputs.mask.shape == torch.Size([self.B, 64])
 
         return outputs
 
@@ -99,6 +96,9 @@ class ViTLitModule(L.LightningModule):
 
         # Forward encoder
         outputs_encoder: dict = self(x)
+        assert outputs_encoder.last_hidden_state.shape == torch.Size([self.B, 17, 768])
+        assert outputs_encoder.ids_restore.shape == torch.Size([self.B, 64])
+        assert outputs_encoder.mask.shape == torch.Size([self.B, 64])
 
         # Forward decoder
         outputs_decoder: dict = self.vit.decoder.forward(
@@ -137,12 +137,13 @@ class ViTLitModule(L.LightningModule):
         # x: torch.Tensor = torch.randn(32, 13, 256, 256)  # BCHW
 
         # Forward encoder
+        self.vit.config.mask_ratio = 0  # disable masking
         outputs_encoder: dict = self(x)
 
         # Get embeddings generated from encoder
         embeddings: torch.Tensor = outputs_encoder.last_hidden_state
         assert embeddings.shape == torch.Size(
-            [self.B, 17, 768]  # (batch_size, sequence_length, hidden_size)
+            [self.B, 65, 768]  # (batch_size, sequence_length, hidden_size)
         )
 
         # Save embeddings in npy format

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -47,9 +47,18 @@ def test_geotiffdatapipemodule(geotiff_folder):
     datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
         data_path=geotiff_folder, batch_size=2
     )
-    datamodule.setup()
 
+    # Train/validation stage
+    datamodule.setup(stage="fit")
     it = iter(datamodule.train_dataloader())
+    image = next(it)
+
+    assert image.shape == torch.Size([2, 3, 256, 256])
+    assert image.dtype == torch.float16
+
+    # Predict stage
+    datamodule.setup(stage="predict")
+    it = iter(datamodule.predict_dataloader())
     image = next(it)
 
     assert image.shape == torch.Size([2, 3, 256, 256])

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -4,7 +4,11 @@ Tests for neural network model architecture.
 Based loosely on Lightning's testing method described at
 https://github.com/Lightning-AI/lightning/blob/2.1.0/.github/CONTRIBUTING.md#how-to-add-new-tests
 """
+import os
+import tempfile
+
 import lightning as L
+import numpy as np
 import pytest
 import torch
 import torchdata
@@ -39,11 +43,21 @@ def test_model_vit(datapipe):
     # Initialize model
     model: L.LightningModule = ViTLitModule()
 
-    # Training
-    trainer: L.Trainer = L.Trainer(
-        accelerator="auto", devices=1, precision="16-mixed", fast_dev_run=True
-    )
-    trainer.fit(model=model, train_dataloaders=dataloader)
+    # Run tests in a temporary folder
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Training
+        trainer: L.Trainer = L.Trainer(
+            accelerator="auto",
+            devices=1,
+            precision="16-mixed",
+            fast_dev_run=True,
+            default_root_dir=tmpdirname,
+        )
+        trainer.fit(model=model, train_dataloaders=dataloader)
 
-    # Test/Evaluation
-    # TODO
+        # Prediction
+        trainer.predict(model=model, dataloaders=dataloader)
+        assert os.path.exists(path := f"{tmpdirname}/data/embeddings/embedding_0.npy")
+        embedding: np.ndarray = np.load(file=path)
+        assert embedding.shape == (2, 17, 768)
+        assert embedding.dtype == "float32"

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -59,5 +59,5 @@ def test_model_vit(datapipe):
         trainer.predict(model=model, dataloaders=dataloader)
         assert os.path.exists(path := f"{tmpdirname}/data/embeddings/embedding_0.npy")
         embedding: np.ndarray = np.load(file=path)
-        assert embedding.shape == (2, 17, 768)
+        assert embedding.shape == (2, 65, 768)
         assert embedding.dtype == "float32"

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -59,6 +59,6 @@ def test_model_vit(datapipe):
         trainer.predict(model=model, dataloaders=dataloader)
         assert os.path.exists(path := f"{tmpdirname}/data/embeddings/embedding_0.npy")
         embeddings: np.ndarray = np.load(file=path)
-        assert embeddings.shape == (2, 65, 768)
+        assert embeddings.shape == (2, 768)
         assert embeddings.dtype == "float32"
         assert not np.isnan(embeddings).any()

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -58,6 +58,7 @@ def test_model_vit(datapipe):
         # Prediction
         trainer.predict(model=model, dataloaders=dataloader)
         assert os.path.exists(path := f"{tmpdirname}/data/embeddings/embedding_0.npy")
-        embedding: np.ndarray = np.load(file=path)
-        assert embedding.shape == (2, 65, 768)
-        assert embedding.dtype == "float32"
+        embeddings: np.ndarray = np.load(file=path)
+        assert embeddings.shape == (2, 65, 768)
+        assert embeddings.dtype == "float32"
+        assert not np.isnan(embeddings).any()


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Generate embeddings from a pretrained ViT encoder, stored in an [npy](https://numpy.org/doc/1.26/reference/generated/numpy.lib.format.html#npy-format) file format.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- In the LightningModule's [`predict_step`](https://lightning.ai/docs/pytorch/2.1.0/common/lightning_module.html#predict-step), implement the logic to do the forward pass and save-to-npy step
- In the LightningDataModule, implement [`predict_dataloader`](https://lightning.ai/docs/pytorch/2.1.0/data/datamodule.html#predict-dataloader)
- Raw embeddings are of shape (1, 65, 768), and we take the mean of the patch embeddings (1, 64, 768) which becomes a (1, 768) shape embedding (see https://github.com/Clay-foundation/model/pull/56#discussion_r1410187302)

![Illustration of how the raw embeddings are turned into the final embeddings of shape (1, 768).](https://github.com/Clay-foundation/model/assets/23487320/6b6719ac-e27b-423b-95cc-30569940f806)

Excalidraw link: https://excalidraw.com/#json=IDteKVYDAHd05wT-rCR6K,vmbiRIb5ucGiXP6R1idu4w

TODO in this PR:
- [x] Implement `predict_dataloader` and `predict_step`
- [x] Add a unit test
- [x] Refactor predict_dataloader to not rely on the validation datapipe
- [x] Compute mean of the raw patch embeddings

TODO in the future:
- [ ] Properly document how to generate/save embeddings and load them (see instructions below)
- [ ] Put some sort of spatiotemporal metadata in the filename of the output embedding
- [ ] Refactor to save only encoder weights to checkpoint instead of entire encoder/decoder network

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Locally, download some GeoTIFF data into the `data/` folder, and then run:
```python
python trainer.py fit --trainer.max_epochs=10 --trainer.precision=bf16-mixed --data.data_path=data/56HKH --data.num_workers=4  # train the model
python trainer.py predict --ckpt_path=checkpoints/last.ckpt --data.batch_size=1 --trainer.limit_predict_batches=1  # generate embeddings
```
  - This should produce an `embedding_0.npy` file under the `data/embeddings/` folder. Sample files (need to unzip):
    - Final embedding of shape (1, 768): [embedding_0.npy.zip](https://github.com/Clay-foundation/model/files/13517583/embedding_0.npy.zip)
    - (for reference) Raw embedding of shape (1, 65, 768):  [embedding_0.npy.zip](https://github.com/Clay-foundation/model/files/13507373/embedding_0.npy.zip)


- Extra configuration options can be found using `python trainer.py predict --help`

To load the embeddings from the npy file:

```python
import numpy as np

array: np.ndarray = np.load(file="embedding_0.npy")
assert array.shape == (1, 768)
```

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->

Towards #3