### PR TITLE
Let LightningDataModule return spatiotemporal metadata

### DIFF
--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -12,10 +12,25 @@ import torchdata
 
 
 # %%
-def _array_to_torch(filepath: str) -> torch.Tensor:
+def _array_to_torch(filepath: str) -> dict[str, torch.Tensor | str]:
     """
-    Read a GeoTIFF file using rasterio into a numpy.ndarray, and convert it
-    to a torch.Tensor (float16 dtype).
+    Read a GeoTIFF file using rasterio into a numpy.ndarray, convert it to a
+    torch.Tensor (float16 dtype), and also output spatiotemporal metadata
+    associated with the image.
+
+    Parameters
+    ----------
+    filepath : str
+        The path to the GeoTIFF file.
+
+    Returns
+    -------
+    outputs : dict
+        A dictionary containing the following items:
+        - image: torch.Tensor - multi-band raster image with shape (Band, Height, Width)
+        - bbox: torch.Tensor - spatial bounding box as (xmin, ymin, xmax, ymax)
+        - crs: torch.Tensor - coordinate reference system as an EPSG code
+        - date: str - the date the image was acquired in YYYY-MM-DD format
     """
     # GeoTIFF - Rasterio
     with rasterio.open(fp=filepath) as dataset:

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -29,7 +29,7 @@ def _array_to_torch(filepath: str) -> dict[str, torch.Tensor | str]:
         A dictionary containing the following items:
         - image: torch.Tensor - multi-band raster image with shape (Band, Height, Width)
         - bbox: torch.Tensor - spatial bounding box as (xmin, ymin, xmax, ymax)
-        - crs: torch.Tensor - coordinate reference system as an EPSG code
+        - epsg: torch.Tensor - coordinate reference system as an EPSG code
         - date: str - the date the image was acquired in YYYY-MM-DD format
     """
     # GeoTIFF - Rasterio
@@ -42,12 +42,12 @@ def _array_to_torch(filepath: str) -> dict[str, torch.Tensor | str]:
         bbox: torch.Tensor = torch.as_tensor(  # xmin, ymin, xmax, ymax
             data=dataset.bounds, dtype=torch.float64
         )
-        crs: int = torch.as_tensor(data=dataset.crs.to_epsg(), dtype=torch.int32)
+        epsg: int = torch.as_tensor(data=dataset.crs.to_epsg(), dtype=torch.int32)
 
         # Get date
         date: str = pathlib.Path(filepath).name[15:25]  # YYYY-MM-DD format
 
-    return {"image": tensor, "bbox": bbox, "crs": crs, "date": date}
+    return {"image": tensor, "bbox": bbox, "epsg": epsg, "date": date}
 
 
 class GeoTIFFDataPipeModule(L.LightningDataModule):

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -91,7 +91,7 @@ class ViTLitModule(L.LightningModule):
         Reference:
         - https://github.com/huggingface/transformers/blob/v4.35.2/src/transformers/models/vit_mae/modeling_vit_mae.py#L948-L1010
         """
-        x: torch.Tensor = batch
+        x: torch.Tensor = batch["image"]
         # x: torch.Tensor = torch.randn(32, 13, 256, 256)  # BCHW
 
         # Forward encoder

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -62,7 +62,7 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
 
     image = batch["image"]
     bbox = batch["bbox"]
-    crs = batch["crs"]
+    epsg = batch["epsg"]
     date = batch["date"]
 
     assert image.shape == torch.Size([2, 3, 256, 256])
@@ -76,6 +76,6 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
         ),
     )
     torch.testing.assert_close(
-        actual=crs, expected=torch.tensor(data=[32646, 32646], dtype=torch.int32)
+        actual=epsg, expected=torch.tensor(data=[32646, 32646], dtype=torch.int32)
     )
     assert date == ["2022-12-31", "2023-12-31"]

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -21,8 +21,8 @@ def fixture_datapipe() -> torchdata.datapipes.iter.IterDataPipe:
     """
     datapipe = torchdata.datapipes.iter.IterableWrapper(
         iterable=[
-            torch.randn(2, 13, 256, 256).to(dtype=torch.float16),
-            torch.randn(2, 13, 256, 256).to(dtype=torch.float16),
+            {"image": torch.randn(2, 13, 256, 256).to(dtype=torch.float16)},
+            {"image": torch.randn(2, 13, 256, 256).to(dtype=torch.float16)},
         ]
     )
     return datapipe

--- a/trainer.py
+++ b/trainer.py
@@ -41,7 +41,7 @@ def cli_main(
     args: ArgsType = None,
 ):
     """
-    Command-line inteface to run ViTLitModule with BaseDataModule.
+    Command-line inteface to run ViTLitModule with GeoTIFFDataPipeModule.
     """
     cli = LightningCLI(
         model_class=ViTLitModule,


### PR DESCRIPTION
Making the LightningDataModule return not only the image, but also spatiotemporal metadata such as:

- bounding box (bbox): (xmin, ymin, xmax, ymax)
- coordinate reference system (epsg): EPSG code
- date: YYYY-MM-DD string format

Note:
- The bbox and epsg is in the raster image's native UTM projection for now, rather than lonlat coordinates.

This is part 1/2 of adding spatiotemporal metadata to the output embedding table later, as mentioned at https://github.com/Clay-foundation/model/issues/35#issuecomment-1839738582.