### PR TITLE
Adapt model to load 512x512 images from s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 *.so
 
 # Checkpoints and logs
-checkpoints/*.ckpt
+checkpoints/**/*.ckpt
 lightning_logs/
 wandb/
 logs/

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ To train the model for a hundred epochs:
 To generate embeddings from the pretrained model's encoder on 1024 images
 (stored as a GeoParquet file with spatiotemporal metadata):
 
-    python trainer.py predict --ckpt_path=checkpoints/last.ckpt --data.batch_size=1000 --trainer.limit_predict_batches=1
+    python trainer.py predict --ckpt_path=checkpoints/last.ckpt \
+                              --data.batch_size=1024 \
+                              --data.data_path=s3://clay-tiles-02 \
+                              --trainer.limit_predict_batches=1
 
 More options can be found using `python trainer.py fit --help`, or at the
 [LightningCLI docs](https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html).

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -117,19 +117,22 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
 
             # Step 3 - Read GeoTIFF into numpy array, batch and convert to torch.Tensor
             self.datapipe_train = (
-                dp_train.map(fn=_array_to_torch)
+                dp_train.sharding_filter()
+                .map(fn=_array_to_torch)
                 .batch(batch_size=self.batch_size)
                 .collate()
             )
             self.datapipe_val = (
-                dp_val.map(fn=_array_to_torch)
+                dp_val.sharding_filter()
+                .map(fn=_array_to_torch)
                 .batch(batch_size=self.batch_size)
                 .collate()
             )
 
         elif stage == "predict":  # prediction loop
             self.datapipe_predict = (
-                self.dp_paths.map(fn=_array_to_torch)
+                self.dp_paths.sharding_filter()
+                .map(fn=_array_to_torch)
                 .batch(batch_size=self.batch_size)
                 .collate()
             )

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -64,7 +64,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
         num_workers: int = 8,
     ):
         """
-        Go from datacubes to 256x256 chips!
+        Go from datacubes to 512x512 chips!
 
         Parameters
         ----------

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -2,6 +2,7 @@
 LightningDataModule to load Earth Observation data from GeoTIFF files using
 rasterio.
 """
+from typing import Literal
 
 import lightning as L
 import numpy as np
@@ -86,20 +87,31 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
         self.batch_size: int = batch_size
         self.num_workers: int = num_workers
 
-    def setup(self, stage: str | None = None):
+    def setup(self, stage: Literal["fit", "predict"] | None = None):
         """
         Data operations to perform on every GPU.
         Split data into training and test sets, etc.
+
+        Parameters
+        ----------
+        stage : str or None
+            Whether to setup the datapipe for the training/validation loop, or
+            the prediction loop. Choose from either 'fit' or 'predict'.
         """
-        # Step 1 - Get list of GeoTIFF filepaths from data/ folder
-        dp_paths = torchdata.datapipes.iter.FileLister(
-            root=self.data_path, masks="*.tif", recursive=True, length=423
-        )
+        # Step 1 - Get list of GeoTIFF filepaths from s3 bucket or data/ folder
+        # self.data_path = "s3://clay-tiles-02/02/"
+        if self.data_path.startswith("s3://"):
+            dp = torchdata.datapipes.iter.IterableWrapper(iterable=[self.data_path])
+            self.dp_paths = dp.list_files_by_s3(masks="*.tif")
+        else:  # if self.data_path is a local data path
+            self.dp_paths = torchdata.datapipes.iter.FileLister(
+                root=self.data_path, masks="*.tif", recursive=True
+            )
 
         if stage == "fit":  # training/validation loop
             # Step 2 - Split GeoTIFF chips into train/val sets (80%/20%)
             # https://pytorch.org/data/0.7/generated/torchdata.datapipes.iter.RandomSplitter.html
-            dp_train, dp_val = dp_paths.random_split(
+            dp_train, dp_val = self.dp_paths.random_split(
                 weights={"train": 0.8, "validation": 0.2}, total_length=423, seed=42
             )
 
@@ -117,7 +129,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
 
         elif stage == "predict":  # prediction loop
             self.datapipe_predict = (
-                dp_paths.map(fn=_array_to_torch)
+                self.dp_paths.map(fn=_array_to_torch)
                 .batch(batch_size=self.batch_size)
                 .collate()
             )

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -99,7 +99,6 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
             the prediction loop. Choose from either 'fit' or 'predict'.
         """
         # Step 1 - Get list of GeoTIFF filepaths from s3 bucket or data/ folder
-        # self.data_path = "s3://clay-tiles-02/02/"
         if self.data_path.startswith("s3://"):
             dp = torchdata.datapipes.iter.IterableWrapper(iterable=[self.data_path])
             self.dp_paths = dp.list_files_by_s3(masks="*.tif")

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -2,7 +2,6 @@
 LightningDataModule to load Earth Observation data from GeoTIFF files using
 rasterio.
 """
-import pathlib
 
 import lightning as L
 import numpy as np
@@ -45,7 +44,7 @@ def _array_to_torch(filepath: str) -> dict[str, torch.Tensor | str]:
         epsg: int = torch.as_tensor(data=dataset.crs.to_epsg(), dtype=torch.int32)
 
         # Get date
-        date: str = pathlib.Path(filepath).name[15:25]  # YYYY-MM-DD format
+        date: str = dataset.tags()["date"]  # YYYY-MM-DD format
 
     return {"image": tensor, "bbox": bbox, "epsg": epsg, "date": date}
 

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -56,14 +56,14 @@ class ViTLitModule(L.LightningModule):
         config_vit = transformers.ViTMAEConfig(
             hidden_size=768,
             num_hidden_layers=12,
-            ntermediate_size=3072,
+            intermediate_size=3072,
             hidden_act="gelu",
             hidden_dropout_prob=0.0,
             attention_probs_dropout_prob=0.0,
             initializer_range=0.02,
             layer_norm_eps=1e-12,
-            image_size=256,  # default was 224
-            patch_size=32,  # default was 16
+            image_size=512,  # default was 224
+            patch_size=64,  # default was 16
             num_channels=13,  # default was 3
             qkv_bias=True,
             decoder_num_attention_heads=16,
@@ -111,7 +111,7 @@ class ViTLitModule(L.LightningModule):
             ids_restore=outputs_encoder.ids_restore,
         )
         # output shape (batch_size, num_patches, patch_size*patch_size*num_channels)
-        assert outputs_decoder.logits.shape == torch.Size([self.B, 64, 13312])
+        assert outputs_decoder.logits.shape == torch.Size([self.B, 64, 53248])
 
         # Log training loss and metrics
         loss: torch.Tensor = self.vit.forward_loss(

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -14,6 +14,8 @@ import shapely
 import torch
 import transformers
 
+torch.set_float32_matmul_precision(precision="medium")
+
 
 # %%
 class ViTLitModule(L.LightningModule):

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -53,7 +53,7 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
     into torch.Tensor objects.
     """
     datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
-        data_path=geotiff_folder, batch_size=2
+        data_path=geotiff_folder, batch_size=2, num_workers=1
     )
 
     # Train/validation/predict stage

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -80,3 +80,24 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
         actual=epsg, expected=torch.tensor(data=[32646, 32646], dtype=torch.int32)
     )
     assert date == ["2022-12-31", "2023-12-31"]
+
+
+def test_geotiffdatapipemodule_list_from_s3_bucket(monkeypatch):
+    """
+    Ensure that GeoTIFFDataPipeModule works to list GeoTIFF data from an s3
+    bucket.
+    """
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
+
+    datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
+        data_path="s3://copernicus-dem-30m/Copernicus_DSM_COG_10_N00_00_E006_00_DEM/",
+        batch_size=1,
+    )
+    datamodule.setup()
+
+    it = iter(datamodule.dp_paths)
+    path = next(it)
+    assert (
+        path
+        == "s3://copernicus-dem-30m/Copernicus_DSM_COG_10_N00_00_E006_00_DEM/AUXFILES/Copernicus_DSM_COG_10_N00_00_E006_00_EDM.tif"
+    )

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -23,9 +23,9 @@ def fixture_geotiff_folder():
     use in the tests.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for filename in [
-            "claytile-12ABC-2022-12-31-01-1",
-            "claytile-12ABC-2023-12-31-01-2",
+        for filename, date in [
+            ("claytile-12ABC-2022-12-31-01-1", "2022-12-31"),
+            ("claytile-12ABC-2023-12-31-01-2", "2023-12-31"),
         ]:
             array: np.ndarray = np.ones(shape=(3, 256, 256))
             with rasterio.open(
@@ -38,6 +38,7 @@ def fixture_geotiff_folder():
                 crs="EPSG:32646",
             ) as dst:
                 dst.write(array)
+                dst.update_tags(date=date)
 
         yield tmpdirname
 

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -27,7 +27,7 @@ def fixture_datapipe() -> torchdata.datapipes.iter.IterDataPipe:
     datapipe = torchdata.datapipes.iter.IterableWrapper(
         iterable=[
             {
-                "image": torch.randn(2, 13, 256, 256).to(dtype=torch.float16),
+                "image": torch.randn(2, 13, 512, 512).to(dtype=torch.float16),
                 "bbox": torch.tensor(
                     data=[
                         [499975.0, 3397465.0, 502535.0, 3400025.0],


### PR DESCRIPTION
Modify the ViT MAE model to accept input images of size 512x512 pixel after #78. Also making a few small enhancements to the datapipe.

TODO:
 - [x] Change hardcoded image_size from 256 to 512, patch_size from 32 to 64.
 - [x] Allow loading of GeoTIFF files directly from s3 bucket instead of local drive
 - [x] Optimize data loading using sharding filter
 - [ ] etc