### PR TITLE
Let ClayDataModule return same spatiotemporal fields as GeoTIFFDataModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To generate embeddings from the pretrained model's encoder on 1024 images
 
     python trainer.py predict --ckpt_path=checkpoints/last.ckpt \
                               --data.batch_size=1024 \
-                              --data.data_path=s3://clay-tiles-02 \
+                              --data.data_dir=s3://clay-tiles-02 \
                               --trainer.limit_predict_batches=1
 
 More options can be found using `python trainer.py fit --help`, or at the

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -53,11 +53,11 @@ class ClayDataset(Dataset):
         return lon, lat
 
     def read_chip(self, chip_path):
+        chip = rasterio.open(chip_path)
+
         # read timestep & normalize
         ts = chip_path.parent.name
         year, month, day = self.normalize_timestamp(ts)
-
-        chip = rasterio.open(chip_path)
 
         # read lat,lon from UTM to WGS84 & normalize
         bounds = chip.bounds
@@ -129,7 +129,7 @@ class ClayDataModule(L.LightningDataModule):
 
     def __init__(
         self,
-        data_dir: Path = Path("data/"),
+        data_dir: str = "data",
         batch_size: int = 4,
         num_workers: int = 8,
     ):
@@ -140,14 +140,15 @@ class ClayDataModule(L.LightningDataModule):
         self.tfm = v2.Compose([v2.Normalize(mean=self.MEAN, std=self.STD)])
 
     def setup(self, stage: str | None = None) -> None:
-        chips_path = list(self.data_dir.glob("**/*.tif"))
-        print(len(chips_path))
-        random.shuffle(chips_path)
-        split_ratio = 0.8
-        split = int(len(chips_path) * split_ratio)
+        if stage == "fit":
+            chips_path = list(Path(self.data_dir).glob("**/*.tif"))
+            print(f"Total number of chips: {len(chips_path)}")
+            random.shuffle(chips_path)
+            split_ratio = 0.8
+            split = int(len(chips_path) * split_ratio)
 
-        self.trn_ds = ClayDataset(chips_path[:split], transform=self.tfm)
-        self.val_ds = ClayDataset(chips_path[split:], transform=self.tfm)
+            self.trn_ds = ClayDataset(chips_path=chips_path[:split], transform=self.tfm)
+            self.val_ds = ClayDataset(chips_path=chips_path[split:], transform=self.tfm)
 
     def train_dataloader(self):
         return DataLoader(
@@ -224,7 +225,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
 
     def __init__(
         self,
-        data_path: str = "data/",
+        data_dir: str = "data/",
         batch_size: int = 32,
         num_workers: int = 8,
     ):
@@ -233,7 +234,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
 
         Parameters
         ----------
-        data_path : str
+        data_dir : str
             Path to the data folder where the GeoTIFF files are stored. Default
             is 'data/'.
         batch_size : int
@@ -248,7 +249,7 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
             A torch DataPipe that can be passed into a torch DataLoader.
         """
         super().__init__()
-        self.data_path: str = data_path
+        self.data_dir: str = data_dir
         self.batch_size: int = batch_size
         self.num_workers: int = num_workers
 
@@ -264,12 +265,12 @@ class GeoTIFFDataPipeModule(L.LightningDataModule):
             the prediction loop. Choose from either 'fit' or 'predict'.
         """
         # Step 1 - Get list of GeoTIFF filepaths from s3 bucket or data/ folder
-        if self.data_path.startswith("s3://"):
-            dp = torchdata.datapipes.iter.IterableWrapper(iterable=[self.data_path])
+        if self.data_dir.startswith("s3://"):
+            dp = torchdata.datapipes.iter.IterableWrapper(iterable=[self.data_dir])
             self.dp_paths = dp.list_files_by_s3(masks="*.tif")
-        else:  # if self.data_path is a local data path
+        else:  # if self.data_dir is a local data path
             self.dp_paths = torchdata.datapipes.iter.FileLister(
-                root=self.data_path, masks="*.tif", recursive=True
+                root=self.data_dir, masks="*.tif", recursive=True
             )
 
         if stage == "fit":  # training/validation loop

--- a/src/model_vit.py
+++ b/src/model_vit.py
@@ -300,7 +300,7 @@ class ViTLitModule(L.LightningModule):
         else:
             print(
                 "No embeddings generated, "
-                f"possibly no GeoTIFF files in {self.trainer.datamodule.data_path}"
+                f"possibly no GeoTIFF files in {self.trainer.datamodule.data_dir}"
             )
             return
 

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -53,7 +53,7 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
     into torch.Tensor objects.
     """
     datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
-        data_path=geotiff_folder, batch_size=2, num_workers=1
+        data_dir=geotiff_folder, batch_size=2, num_workers=1
     )
 
     # Train/validation/predict stage
@@ -95,7 +95,7 @@ def test_geotiffdatapipemodule_list_from_s3_bucket(monkeypatch):
     monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
 
     datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
-        data_path="s3://copernicus-dem-30m/Copernicus_DSM_COG_10_N00_00_E006_00_DEM/",
+        data_dir="s3://copernicus-dem-30m/Copernicus_DSM_COG_10_N00_00_E006_00_DEM/",
         batch_size=1,
     )
     datamodule.setup()


### PR DESCRIPTION
Align the torch Dataset-based ClayDataModule developed in #47 with the torchdata-based GeoTIFFDataModule (mainly #66), so that both are consistent in terms of the input parameters and returned values.

TODO:
- [x] Standardize on the parameter `data_dir` with a `str` type
- [x] Get YYYY-MM-DD timestamp from GeoTIFF's metadata rather than filename, xref #70
- [x] Simplify calculation of latlon centroid value
- [x] Let ClayDataset return the UTM bounding box and EPSG code as in #66

This is part 1/3 of setting things up for the next round of embedding generation to conform to the GeoParquet table format in #86.