### PR TITLE
Allow ClayDataModule to load GeoTIFF files directly from s3

### DIFF
--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -163,6 +163,9 @@ class ClayDataModule(L.LightningDataModule):
             self.trn_ds = ClayDataset(chips_path=chips_path[:split], transform=self.tfm)
             self.val_ds = ClayDataset(chips_path=chips_path[split:], transform=self.tfm)
 
+        elif stage == "predict":
+            self.prd_ds = ClayDataset(chips_path=chips_path, transform=self.tfm)
+
     def train_dataloader(self):
         return DataLoader(
             self.trn_ds,
@@ -179,6 +182,14 @@ class ClayDataModule(L.LightningDataModule):
             num_workers=self.num_workers,
             shuffle=False,
             pin_memory=True,
+        )
+
+    def predict_dataloader(self):
+        return DataLoader(
+            dataset=self.prd_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            shuffle=False,
         )
 
 

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -86,7 +86,7 @@ class ClayDataset(Dataset):
         cube["date"] = str(cube["date"])
         cube["latlon"] = torch.as_tensor(data=cube["latlon"])
         cube["timestep"] = torch.as_tensor(data=cube["timestep"])
-        cube["path"] = str(chip_path.absolute())
+        cube["source_url"] = str(getattr(chip_path, "absolute", chip_path))
 
         if self.transform:
             # convert to float16 and normalize

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -86,7 +86,10 @@ class ClayDataset(Dataset):
         cube["date"] = str(cube["date"])
         cube["latlon"] = torch.as_tensor(data=cube["latlon"])
         cube["timestep"] = torch.as_tensor(data=cube["timestep"])
-        cube["source_url"] = str(getattr(chip_path, "absolute", chip_path))
+        try:
+            cube["source_url"] = str(chip_path.absolute())
+        except AttributeError:
+            cube["source_url"] = chip_path
 
         if self.transform:
             # convert to float16 and normalize

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -3,6 +3,7 @@ LightningDataModule to load Earth Observation data from GeoTIFF files using
 rasterio.
 """
 import math
+import os
 import random
 from pathlib import Path
 from typing import List, Literal
@@ -14,6 +15,9 @@ import torch
 import torchdata
 from torch.utils.data import DataLoader, Dataset
 from torchvision.transforms import v2
+
+os.environ["GDAL_DISABLE_READDIR_ON_OPEN"] = "EMPTY_DIR"
+os.environ["GDAL_HTTP_MERGE_CONSECUTIVE_RANGES"] = "YES"
 
 
 # %%

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -12,7 +12,7 @@ import pytest
 import rasterio
 import torch
 
-from src.datamodule import GeoTIFFDataPipeModule
+from src.datamodule import ClayDataModule, GeoTIFFDataPipeModule
 
 
 # %%
@@ -27,14 +27,14 @@ def fixture_geotiff_folder():
             ("claytile-12ABC-2022-12-31-01-1", "2022-12-31"),
             ("claytile-12ABC-2023-12-31-01-2", "2023-12-31"),
         ]:
-            array: np.ndarray = np.ones(shape=(3, 256, 256))
+            array: np.ndarray = np.ones(shape=(13, 256, 256))
             with rasterio.open(
                 fp=f"{tmpdirname}/{filename}.tif",
                 mode="w",
                 width=256,
                 height=256,
-                count=3,
-                dtype=rasterio.uint16,
+                count=13,
+                dtype=rasterio.int16,
                 crs="EPSG:32646",
             ) as dst:
                 dst.write(array)
@@ -44,30 +44,32 @@ def fixture_geotiff_folder():
 
 
 # %%
+@pytest.mark.parametrize("datamodule", [GeoTIFFDataPipeModule, ClayDataModule])
 @pytest.mark.parametrize(
     "stage,dataloader", [("fit", "train_dataloader"), ("predict", "predict_dataloader")]
 )
-def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
+def test_datapipemodule(datamodule, geotiff_folder, stage, dataloader):
     """
     Ensure that GeoTIFFDataPipeModule works to load data from a GeoTIFF file
     into torch.Tensor objects.
     """
-    datamodule: L.LightningDataModule = GeoTIFFDataPipeModule(
+    datamodule: L.LightningDataModule = datamodule(
         data_dir=geotiff_folder, batch_size=2, num_workers=1
     )
+    datamodule.split_ratio = 1.0  # disable train/val split for determinism
 
     # Train/validation/predict stage
     datamodule.setup(stage=stage)
     it = iter(getattr(datamodule, dataloader)())
     batch = next(it)
 
-    image = batch["image"]
+    image = batch.get("image" if "image" in batch else "pixels")
     bbox = batch["bbox"]
     epsg = batch["epsg"]
     date = batch["date"]
     source_url = batch["source_url"]
 
-    assert image.shape == torch.Size([2, 3, 256, 256])
+    assert image.shape == torch.Size([2, 13, 256, 256])
     assert image.dtype == torch.float16
 
     torch.testing.assert_close(
@@ -80,8 +82,8 @@ def test_geotiffdatapipemodule(geotiff_folder, stage, dataloader):
     torch.testing.assert_close(
         actual=epsg, expected=torch.tensor(data=[32646, 32646], dtype=torch.int32)
     )
-    assert date == ["2022-12-31", "2023-12-31"]
-    assert source_url == [
+    assert sorted(date) == ["2022-12-31", "2023-12-31"]
+    assert sorted(source_url) == [
         f"{geotiff_folder}/claytile-12ABC-2022-12-31-01-1.tif",
         f"{geotiff_folder}/claytile-12ABC-2023-12-31-01-2.tif",
     ]

--- a/src/tests/test_datamodule.py
+++ b/src/tests/test_datamodule.py
@@ -1,5 +1,5 @@
 """
-Tests for GeoTIFFDataPipeModule.
+Tests for LightningDataModules.
 
 Integration test for the entire data pipeline from loading the data and
 pre-processing steps, up to the DataLoader producing mini-batches.
@@ -44,14 +44,14 @@ def fixture_geotiff_folder():
 
 
 # %%
-@pytest.mark.parametrize("datamodule", [GeoTIFFDataPipeModule, ClayDataModule])
+@pytest.mark.parametrize("datamodule", [ClayDataModule, GeoTIFFDataPipeModule])
 @pytest.mark.parametrize(
     "stage,dataloader", [("fit", "train_dataloader"), ("predict", "predict_dataloader")]
 )
 def test_datapipemodule(datamodule, geotiff_folder, stage, dataloader):
     """
-    Ensure that GeoTIFFDataPipeModule works to load data from a GeoTIFF file
-    into torch.Tensor objects.
+    Ensure that ClayDataModule and GeoTIFFDataPipeModule works to load data
+    from a GeoTIFF file into torch.Tensor objects.
     """
     datamodule: L.LightningDataModule = datamodule(
         data_dir=geotiff_folder, batch_size=2, num_workers=1


### PR DESCRIPTION
Similar to work done in #85 on the GeoTIFFDataPipeModule, this PR implements similar functionality in ClayDataModule to load GeoTIFF files from an s3 bucket. Plus a few more minor tweaks to align both LightningDataModules.

Implementation uses `torchdata`'s [S3FileLister](https://pytorch.org/data/0.7/generated/torchdata.datapipes.iter.S3FileLister.html#torchdata.datapipes.iter.S3FileLister) to get the files, but instead of returning an iterator, a list is returned.

TODO:
- [x] Allow ClayDataModule to load GeoTIFF files directly from s3
- [x] Rename `datacube["path"]` to `datacube["source_url"]` to match #86
- [x] Implement predict dataloader
- [x] Add a unit test

Continuing on from #91, this PR is part 2/3 of working towards generating new embeddings from the model developed at #47.