### PR TITLE
Document how the benchmark dataset labels were prepared

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -8,6 +8,10 @@ parts:
   chapters:
     - title: Installation
       file: installation
+- caption: Data Preparation
+  chapters:
+    - title: Benchmark dataset labels
+      file: data_labels
 - caption: Running the model
   chapters:
     - title: Generating embeddings

--- a/docs/data_labels.md
+++ b/docs/data_labels.md
@@ -1,0 +1,57 @@
+# Benchmark dataset labels
+
+A benchmark dataset is a collection of data used for evaluating the performance
+of algorithms, models or systems in a specific field of study. These datasets
+are crucial in providing a common ground for comparing different approaches,
+allowing researchers to assess the strengths and weaknesses of various methods.
+For Clay, we evaluate our model on benchmark datasets with suitable downstream
+tasks.
+
+For our initial benchmark dataset, we've implemented the
+[Cloud to Street - Microsoft flood dataset](https://beta.source.coop/repositories/c2sms/c2smsfloods/description).
+It is what we will use in our initial linear probing experiments and
+evaluation of finetuning on a downstream task. The task itself is
+[segmentation](https://paperswithcode.com/task/semantic-segmentation) of water
+pixels associated with recorded flood events.
+
+The original dataset consists of 2/3 of our Foundation model's datacube inputs
+(Sentinel-1 and Sentinel-2) along with raster water mask labels for both
+sensors. Each image is 512x512 pixels in terms of width and height. The
+original Sentinel-2 images are L1C, which is Top-of-Atmosphere reflectance. We
+are training Clay with surface reflectance, however, so we ultimately used the
+geospatial bounds from the GeoTIFF and image timestamp (from the granule name)
+to query
+[Microsoft Planetary Computer's STAC API for L2A (Bottom-of-Atmosphere a.k.a. "surface reflectance") Sentinel-2](https://planetarycomputer.microsoft.com/dataset/sentinel-2-l2a)
+scenes in the same time and space, with the same channels expected by Clay. We
+then followed the same `datacube` creation logic to generate datacubes with
+Sentinel-1 VV and VH and the Copernicus digital elevation model (DEM). We also
+ensured that the Sentinel-1 data was within a +/- 3 day interval of each
+reference Sentinel-2 scene (same method used by the benchmark dataset authors)
+and that the Sentinel-1 data was indeed already included in the bechmark
+datasets list of granules. The datacubes generated have all three inputs
+matching the exact specs of the Foundation model's training data, at 512x512
+pixels.
+
+Here is an example of a datacube we generated for the dataset:
+
+![datacube](https://github.com/Clay-foundation/model/assets/23487320/94dffcf5-4075-4c17-ac96-01c11bcb299b)
+
+The images left to right show a true color representation of the Sentinel-2
+scene, the Sentinel-1 VH polarization and the digital elevation model.
+
+![gt](https://github.com/Clay-foundation/model/assets/23487320/4ac92af7-6931-4249-a920-7d29453b9b31)
+
+Here we have something similar, but this time just the Sentinel-1 and
+Sentinel-2 scenes with the Sentinel-1 water mask (ground truth) overlaid.
+
+Last note on this benchmark dataset that we've adapted for Clay, we made sure
+to preserve the metadata for timestamp and geospatial coordinates in the
+datacube such that we can embed information in the way that the Clay Foundation
+model expects. We also preserve the flood event information too, for analysis
+during finetuning.
+
+The script for generating these datacubes is at
+https://github.com/Clay-foundation/model/blob/c2smsfloods_benchmark_datapipeline/scripts/datacube_benchmark.py.
+You'll need an AWS account and Microsoft Planetary Computer API Key to run
+this. The data is queried from Microsoft Planetary Computer STAC APIs, read and
+processed in memory, and the datacubes are written directly to AWS S3.


### PR DESCRIPTION
Mention why we decided to use Cloud to Street for the initial benchmark dataset, and how the imagery and label data was processed to fit into the Clay Foundation model.

Opening this PR on behalf of @lillythomas who did the actual work and who wrote the original Jupyter notebook. The Jupyter Notebook has been converted to Markdown for easier visibilty on GitHub.

Screenshot:

![image](https://github.com/Clay-foundation/model/assets/23487320/a2a5e279-8b53-4a33-8c79-f206fca161b6)

Part of #90