### PR TITLE
Revert nbdev CI setup to go back to Jupyter Book

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,48 +1,81 @@
-name: Deploy to GitHub Pages
-on:
-  push:
-    branches: [master, nbdev]
-  workflow_dispatch:
+# https://jupyterbook.org/en/stable/publish/gh-pages.html#automatically-host-your-book-with-github-actions
+name: deploy-book
 
-permissions:
-  contents: write
+# Only run this when the main branch changes
+on:
+  # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
+  # pull_request:
+  push:
+    branches:
+      - main
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    paths:
+      - '.github/workflows/deploy-book.yml'
+      - 'docs/**'
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build_and_deploy:
-    runs-on: ubuntu-latest
+  # This job installs dependencies, builds the book, and pushes it to `gh-pages`
+  build-book:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-        cache: "pip"
-        cache-dependency-path: settings.ini
-    - name: Install Dependencies
-      env:
-        USE_PRE: ''
-        TORCH_CPU: true
-      shell: bash
-      run: |
-        set -ux
-        python -m pip install --upgrade pip
-        if [ $USE_PRE ]; then
-          pip install -Uq git+https://github.com/fastai/ghapi.git
-          pip install -Uq git+https://github.com/fastai/fastcore.git
-          pip install -Uq git+https://github.com/fastai/execnb.git
-          pip install -Uq git+https://github.com/fastai/nbdev.git
-          wget -q $(curl https://latest.fast.ai/pre/quarto-dev/quarto-cli/linux-amd64.deb)
-          sudo dpkg -i quarto*.deb
-        else
-          pip install -Uq nbdev
-        fi
-        if [ $TORCH_CPU ]; then
-          test -f setup.py && pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
-        else
-          test -f setup.py && pip install -e ".[dev]"
-        fi
-        cd docs && nbdev_docs
-    - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.4.3
-      with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: docs/_docs/ # The folder the action should deploy.
+      # Checkout current git repository
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # Enable GitHub Pages and extract various metadata about a site
+      - name: Setup Pages
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
+
+      # Install Micromamba with conda-forge dependencies
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@e820223f89c8720d6c740ca154a7adf32fcd278a # v1.7.3
+        with:
+          environment-name: claymodel
+          condarc: |
+            channels:
+              - conda-forge
+              - nodefaults
+          create-args: >-
+            python=3.11
+            jupyter-book=0.15.1
+
+      # Build the Jupyter book
+      - name: Build the book
+        run: jupyter-book build docs/
+
+      # Upload the built HTML to GitHub Artifacts
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
+        with:
+          path: docs/_build/html
+
+  # This job downloads the built HTML artifacts and deploys the webpage
+  deploy-pages:
+    runs-on: ubuntu-22.04
+    # Add a dependency to the build job
+    needs: build-book
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      # Push the book's HTML to github-pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1


### PR DESCRIPTION
This reverts commit 6d3ca675e6a912b8e521757f1e07dc7d2d44334b that had set up the Continuous Integration for building docs using nbdev. There was an attempt to spin off the documentation to a separate repo (see #102, #103, #104), but we're now going back to the original Jupyter Book setup (#89).

Note that proper branch protections are now in place to prevent direct pushes to the `main` branch, such that all pushes to `main` will require a Pull Request.