### PR TITLE
Embedding factory script looping through each MGRS tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,17 @@ To generate embeddings from the pretrained model's encoder on 1024 images
 
 More options can be found using `python trainer.py fit --help`, or at the
 [LightningCLI docs](https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html).
+
+
+## Generating the embeddings
+
+Get the list of MGRS tiles & store them inside `mgrs_world.txt`:
+
+    aws s3 ls s3://clay-tiles-02/02/ | tr -s ' ' |  cut -d ' ' -f 3 | cut -d '/' -f 1 > mgrs_world.txt
+
+To get embeddings from a specific CLAY model checkpoint:
+
+    python generate_embeddings.py mgrs_world.txt checkpoints/<checkpoint-name>.ckpt
+
+To push the embeddings into s3:
+    aws s3 sync data/embeddings/ s3://clay-vector-embeddings/<version>/<yyyymmdd>/

--- a/generate_embeddings.ipynb
+++ b/generate_embeddings.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5ea23f97-50ba-4ddf-b856-a087e3ba3d55",
+   "metadata": {},
+   "source": [
+    "# Embeddings factory script\n",
+    "\n",
+    "Generate embeddings in bulk, on a per MGRS tile basis.\n",
+    "\n",
+    "Embeddings are stored into the `data/embeddings/` folder,\n",
+    "and then uploaded to `s3://clay-vector-embeddings/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b60152d-d504-4d59-b6de-d3a3a4526e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "import duckdb\n",
+    "import lightning as L\n",
+    "import torch\n",
+    "import tqdm\n",
+    "\n",
+    "from src.datamodule import ClayDataModule\n",
+    "from src.model_clay import CLAYModule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ae87a839-467c-4b18-9cf0-b540f9f1f6f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set some environment variables and parameters\n",
+    "torch.set_float32_matmul_precision(precision=\"medium\")\n",
+    "os.environ[\"TORCH_CUDNN_V8_API_DISABLED\"] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "95d01b40-f06d-4634-bbfb-dcb094361e46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate list of MGRS tiles\n",
+    "#!aws s3 ls s3://clay-tiles-02/02/ | tr -s ' ' |  cut -d ' ' -f 3 | cut -d '/' -f 1 > mgrs_world.txt\n",
+    "mgrs_tiles = open(file=\"mgrs_world.txt\").read().splitlines()\n",
+    "mgrs_tiles.sort(key=lambda m: m[2])  # sort by latitudinal band from South to North"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "83ea0ca1-b6e3-4d6f-9f27-b1cd806c235e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using bfloat16 Automatic Mixed Precision (AMP)\n",
+      "GPU available: True (cuda), used: True\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "IPU available: False, using: 0 IPUs\n",
+      "HPU available: False, using: 0 HPUs\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Setup trainer and load model weights from checkpoint\n",
+    "# !aws s3 cp s3://clay-model-ckpt/v0/clay-small-70MT-1100T-10E.ckpt checkpoints/\n",
+    "trainer = L.Trainer(precision=\"bf16-mixed\", logger=False)\n",
+    "model: L.LightningModule = CLAYModule.load_from_checkpoint(\n",
+    "    checkpoint_path=\"checkpoints/clay-small-70MT-1100T-10E.ckpt\"\n",
+    ")\n",
+    "#!mamba install triton\n",
+    "# model.model.encoder = torch.compile(model=model.model.encoder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "375c4294-d7a4-40eb-973f-16e517fec0b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing MGRS Tile 59HQB:   0%|                      | 0/1203 [00:00<?, ?it/s]\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predicting: |                                             | 0/? [00:00<?, ?it/s]"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate embeddings for each MGRS tile\n",
+    "for mgrs_tile in (pbar := tqdm.tqdm(iterable=mgrs_tiles)):\n",
+    "    if len(glob.glob(pathname=f\"data/embeddings/{mgrs_tile}_*.gpq\")) == 0:\n",
+    "        pbar.set_description(desc=f\"Processing MGRS Tile {mgrs_tile}\")\n",
+    "        datamodule: L.LightningDataModule = ClayDataModule(\n",
+    "            data_dir=f\"s3://clay-tiles-02/02/{mgrs_tile}\", batch_size=32, num_workers=16\n",
+    "        )\n",
+    "        try:\n",
+    "            trainer.predict(model=model, datamodule=datamodule)\n",
+    "            !aws s3 cp data/embeddings/$mgrs_tile*.gpq s3://clay-vector-embeddings/v001/\n",
+    "        except RuntimeError as err:\n",
+    "            print(f\"Processing of MGRS Tile {mgrs_tile} failed because of {err}\")\n",
+    "            warnings.warn(message=repr(err))\n",
+    "        except AssertionError as err:\n",
+    "            print(f\"Processing of MGRS Tile {mgrs_tile} failed because of {err}\")\n",
+    "            warnings.warn(message=repr(err))\n",
+    "\n",
+    "print(\"All done!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf14d702-be3e-4f8b-aaab-714e685c78b8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7f73c372-e7f4-40cd-aedc-1f901ad8d802",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌──────────────┐\n",
+       "│ count_star() │\n",
+       "│    int64     │\n",
+       "├──────────────┤\n",
+       "│       947019 │\n",
+       "└──────────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duckdb.sql(query=\"SELECT COUNT(*) from read_parquet('data/embeddings/*.gpq')\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09a329b2-1d60-499d-8b94-4b0102dd9e4d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "claymodel",
+   "language": "python",
+   "name": "claymodel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -37,10 +37,7 @@ def main(mgrs_tiles_path, checkpoint_path):
             )
             try:
                 trainer.predict(model=model, datamodule=datamodule)
-            except RuntimeError as err:
-                print(f"Processing of MGRS Tile {mgrs_tile} failed because of {err}")
-                warnings.warn(message=repr(err))
-            except AssertionError as err:
+            except Exception as err:
                 print(f"Processing of MGRS Tile {mgrs_tile} failed because of {err}")
                 warnings.warn(message=repr(err))
 

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -3,13 +3,12 @@ import os
 import sys
 import warnings
 
-import tqdm
 import lightning as L
 import torch
+import tqdm
 
 from src.datamodule import ClayDataModule
 from src.model_clay import CLAYModule
-
 
 # Set some environment variables and parameters
 torch.set_float32_matmul_precision(precision="medium")

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -1,0 +1,53 @@
+import glob
+import os
+import sys
+import warnings
+
+import tqdm
+import lightning as L
+import torch
+
+from src.datamodule import ClayDataModule
+from src.model_clay import CLAYModule
+
+
+# Set some environment variables and parameters
+torch.set_float32_matmul_precision(precision="medium")
+os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
+
+
+def main(mgrs_tiles_path, checkpoint_path):
+    # Load MGRS tiles
+    mgrs_tiles = open(file=mgrs_tiles_path).read().splitlines()
+    mgrs_tiles.sort(key=lambda m: m[2])
+
+    # Setup trainer and load model weights from checkpoint
+    trainer = L.Trainer(precision="bf16-mixed", logger=False)
+    model: L.LightningModule = CLAYModule.load_from_checkpoint(
+        checkpoint_path=checkpoint_path
+    )
+
+    # Generate embeddings for each MGRS tile
+    for mgrs_tile in (pbar := tqdm.tqdm(iterable=mgrs_tiles)):
+        if len(glob.glob(pathname=f"data/embeddings/{mgrs_tile}_*.gpq")) == 0:
+            pbar.set_description(desc=f"Processing MGRS Tile {mgrs_tile}")
+            datamodule: L.LightningDataModule = ClayDataModule(
+                data_dir=f"s3://clay-tiles-02/02/{mgrs_tile}",
+                batch_size=32,
+                num_workers=16,
+            )
+            try:
+                trainer.predict(model=model, datamodule=datamodule)
+            except RuntimeError as err:
+                print(f"Processing of MGRS Tile {mgrs_tile} failed because of {err}")
+                warnings.warn(message=repr(err))
+            except AssertionError as err:
+                print(f"Processing of MGRS Tile {mgrs_tile} failed because of {err}")
+                warnings.warn(message=repr(err))
+
+    print("All done!")
+
+
+if __name__ == "__main__":
+    # Usage: python scripts/generate_embeddings.py mgrs_tiles.txt checkpoints/epoch=0-step=0.ckpt
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Jupyter notebook script to generate GeoParquet embedding files on a per MGRS tile basis.

Steps:
1. The script first generates an mgrs_world.txt file with a list of MGRS code names like 12ABC. Need to run this command first:
    ```
    aws s3 ls s3://clay-tiles-02/02/ | tr -s ' ' |  cut -d ' ' -f 3 | cut -d '/' -f 1 > mgrs_world.txt
    ```
2. A for-loop then goes through each MGRS tile, with the model running the prediction to generate GeoParquet files that are uploaded to s3.

Notes:
- There were about 947019 rows of embeddings generated from the clay-small-70MT-1100T-10E.ckpt model checkpoint in Dec 2023.
- Embeddings were generated using a `g5.4xlarge` EC2 instance with 1 NVIDIA A10G GPU that allows for bfloat16 dtype calculations.

Closes #120