### PR TITLE
Add option to output raw patch embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ docs/_build/
 # Mac OS-specific storage files
 .DS_Store
 datadisk/
+
+# vscode
+.vscode

--- a/docs/model_embeddings.md
+++ b/docs/model_embeddings.md
@@ -45,8 +45,7 @@ Step by step instructions to create embeddings for a single MGRS tile location
                              --data.data_dir=s3://clay-tiles-02/02/27WXN \
                              --data.batch_size=32 \
                              --data.num_workers=16 \
-                             --model.embeddings_level=group \
-                             --model.shuffle=False
+                             --model.embeddings_level=group
    ```
 
    This should output a GeoParquet file containing the embeddings for MGRS tile
@@ -65,9 +64,6 @@ Step by step instructions to create embeddings for a single MGRS tile location
    The embeddings are flattened into one dimensional arrays because pandas
    does not allow for multidimensional arrays. This makes it necessary to
    reshape the flattened arrays to access the patch level embeddings.
-
-   The `shuffle` flag should be set to `False` of the `output_patch_embeddings` is
-   `True` to ensure that the order of the patch embeddings is not randomized.
 
    ```{note}
    For those interested in how the embeddings were computed, the predict step

--- a/docs/model_embeddings.md
+++ b/docs/model_embeddings.md
@@ -44,8 +44,8 @@ Step by step instructions to create embeddings for a single MGRS tile location
                              --trainer.precision=bf16-mixed \
                              --data.data_dir=s3://clay-tiles-02/02/27WXN \
                              --data.batch_size=32 \
-                             --data.num_workers=16
-                             --output-patch-embeddings=False
+                             --data.num_workers=16 \
+                             --output-patch-embeddings=False \
                              --shuffle=False
    ```
 
@@ -155,4 +155,18 @@ print(geodataframe)
 Further reading:
 - https://guide.cloudnativegeo.org/geoparquet
 - https://cloudnativegeo.org/blog/2023/10/the-geoparquet-ecosystem-at-1.0.0
+```
+
+## Converting to patch level embeddings
+
+In the case where patch level embeddings are requested, the resulting array
+will have all patch embeddings ravelled in one row. Each row represents a
+512x512 pixel image, and contains 16x16 patch embeddings.
+
+To convert each row into patch level embeddings, the embedding array has to
+be split
+
+```{code}
+ravelled_patch_embeddings = geodataframe.embeddings[0]
+patch_embeddings = ravelled_patch_embeddings.reshape(256, 768)
 ```

--- a/docs/model_embeddings.md
+++ b/docs/model_embeddings.md
@@ -45,8 +45,8 @@ Step by step instructions to create embeddings for a single MGRS tile location
                              --data.data_dir=s3://clay-tiles-02/02/27WXN \
                              --data.batch_size=32 \
                              --data.num_workers=16 \
-                             --output-patch-embeddings=False \
-                             --shuffle=False
+                             --model.output_patch_embeddings=False \
+                             --model.shuffle=False
    ```
 
    This should output a GeoParquet file containing the embeddings for MGRS tile

--- a/docs/model_embeddings.md
+++ b/docs/model_embeddings.md
@@ -164,7 +164,7 @@ will have all patch embeddings ravelled in one row. Each row represents a
 512x512 pixel image, and contains 16x16 patch embeddings.
 
 To convert each row into patch level embeddings, the embedding array has to
-be split
+be unravelled into 256 patches like so
 
 ```{code}
 ravelled_patch_embeddings = geodataframe.embeddings[0]

--- a/src/model_clay.py
+++ b/src/model_clay.py
@@ -946,7 +946,7 @@ class CLAYModule(L.LightningModule):
                     dtype="date32[day][pyarrow]"
                 ),
                 "embeddings": pa.FixedShapeTensorArray.from_numpy_ndarray(
-                    embeddings_output.cpu().detach().__array__()
+                    np.ascontiguousarray(embeddings_output.cpu().detach().__array__())
                 ),
             },
             geometry=shapely.box(

--- a/src/model_clay.py
+++ b/src/model_clay.py
@@ -797,6 +797,7 @@ class CLAYModule(L.LightningModule):
         b1=0.9,
         b2=0.95,
         output_patch_embeddings=False,
+        shuffle=True,
     ):
         super().__init__()
         self.save_hyperparameters(logger=True)
@@ -811,6 +812,7 @@ class CLAYModule(L.LightningModule):
                 mask_ratio=mask_ratio,
                 image_size=image_size,
                 patch_size=patch_size,
+                shuffle=shuffle,
             )
         else:
             raise ValueError(
@@ -889,6 +891,9 @@ class CLAYModule(L.LightningModule):
         assert not torch.isnan(embeddings_raw).any()  # ensure no NaNs in embedding
 
         if self.hparams.output_patch_embeddings:
+            # Take the mean of the embeddings along the group dimension
+            # excluding the last two latlon_ and time_ embeddings. This
+            # results in one embedding per patch.
             embeddings_raw = rearrange(
                 embeddings_raw[:, :-2, :], "b (g l) s -> b g (l s)", l=256, g=6
             )

--- a/src/model_clay.py
+++ b/src/model_clay.py
@@ -798,7 +798,6 @@ class CLAYModule(L.LightningModule):
         b1=0.9,
         b2=0.95,
         embeddings_level: Literal["mean", "patch", "group"] = "mean",
-        shuffle=True,
     ):
         super().__init__()
         self.save_hyperparameters(logger=True)
@@ -813,7 +812,6 @@ class CLAYModule(L.LightningModule):
                 mask_ratio=mask_ratio,
                 image_size=image_size,
                 patch_size=patch_size,
-                shuffle=shuffle,
             )
         else:
             raise ValueError(

--- a/src/model_clay.py
+++ b/src/model_clay.py
@@ -890,9 +890,9 @@ class CLAYModule(L.LightningModule):
 
         if self.hparams.output_patch_embeddings:
             embeddings_raw = rearrange(
-                embeddings_raw[:, :-2, :], "b (w h g) s -> b (w h s) g", w=16, h=16, g=6
+                embeddings_raw[:, :-2, :], "b (g l) s -> b g (l s)", l=256, g=6
             )
-            embeddings_mean: torch.Tensor = embeddings_raw.mean(dim=2)
+            embeddings_mean = reduce(embeddings_raw, "b g s -> b s", "mean")
             assert embeddings_mean.shape == torch.Size(
                 [
                     self.model.encoder.B,

--- a/src/model_clay.py
+++ b/src/model_clay.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import Literal
 
 import geopandas as gpd
 import lightning as L
@@ -796,7 +797,7 @@ class CLAYModule(L.LightningModule):
         wd=0.05,
         b1=0.9,
         b2=0.95,
-        output_patch_embeddings=False,
+        embeddings_level: Literal["mean", "patch", "group"] = "mean",
         shuffle=True,
     ):
         super().__init__()
@@ -890,28 +891,44 @@ class CLAYModule(L.LightningModule):
         )
         assert not torch.isnan(embeddings_raw).any()  # ensure no NaNs in embedding
 
-        if self.hparams.output_patch_embeddings:
-            # Take the mean of the embeddings along the group dimension
-            # excluding the last two latlon_ and time_ embeddings. This
-            # results in one embedding per patch.
-            embeddings_raw = rearrange(
-                embeddings_raw[:, :-2, :], "b (g l) s -> b g (l s)", l=256, g=6
-            )
-            embeddings_mean = reduce(embeddings_raw, "b g s -> b s", "mean")
-            assert embeddings_mean.shape == torch.Size(
-                [
-                    self.model.encoder.B,
-                    256 * 768,
-                ]  # (batch_size, nr of patches * hidden_size)
-            )
-        else:
+        if self.hparams.embeddings_level == "mean":
             # Take the mean of the embeddings along the sequence_length dimension
             # excluding the last two latlon_ and time_ embeddings, i.e. compute
             # mean over patch embeddings only
-            embeddings_mean: torch.Tensor = embeddings_raw[:, :-2, :].mean(dim=1)
-            assert embeddings_mean.shape == torch.Size(
-                [self.model.encoder.B, 768]  # (batch_size, hidden_size)
+            embeddings_output: torch.Tensor = embeddings_raw[:, :-2, :].mean(dim=1)
+            expected_size = [self.model.encoder.B, 768]  # (batch_size, hidden_size)
+        elif self.hparams.embeddings_level in ["patch", "group"]:
+            # Take the mean of the embeddings along the group dimension
+            # excluding the last two latlon_ and time_ embeddings. This
+            # results in one embedding per patch.
+            embeddings_output = rearrange(
+                embeddings_raw[:, :-2, :], "b (g h w) d -> b g h w d", w=16, h=16, g=6
             )
+            if self.hparams.embeddings_level == "patch":
+                embeddings_output = reduce(
+                    embeddings_output, "b g h w d -> b h w d", "mean"
+                )
+                expected_size = [
+                    self.model.encoder.B,
+                    16,
+                    16,
+                    768,
+                ]
+            else:
+                expected_size = [
+                    self.model.encoder.B,
+                    6,
+                    16,
+                    16,
+                    768,
+                ]
+        else:
+            raise ValueError(
+                f"Value {self.hparams.embeddings_level} no allowed. "
+                "Choose one from mean, patch, or group"
+            )
+
+        assert embeddings_output.shape == torch.Size(expected_size)
 
         # Create table to store the embeddings with spatiotemporal metadata
         unique_epsg_codes = set(int(epsg) for epsg in epsgs)
@@ -929,7 +946,7 @@ class CLAYModule(L.LightningModule):
                     dtype="date32[day][pyarrow]"
                 ),
                 "embeddings": pa.FixedShapeTensorArray.from_numpy_ndarray(
-                    embeddings_mean.cpu().detach().__array__()
+                    embeddings_output.cpu().detach().__array__()
                 ),
             },
             geometry=shapely.box(

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -91,13 +91,7 @@ def test_model_vit_fit(datapipe):
         (ViTLitModule, "bf16-mixed"),
     ],
 )
-@pytest.mark.parametrize(
-    "litmodule,output_patch_embeddings",
-    [
-        (CLAYModule, True),
-        (CLAYModule, False),
-    ],
-)
+@pytest.mark.parametrize("output_patch_embeddings", [True, False])
 def test_model_predict(datapipe, litmodule, precision, output_patch_embeddings):
     """
     Run a single prediction loop using 1 batch.

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -100,7 +100,10 @@ def test_model_predict(datapipe, litmodule, precision, output_patch_embeddings):
     dataloader = torchdata.dataloader2.DataLoader2(datapipe=datapipe)
 
     # Initialize model
-    model: L.LightningModule = litmodule()
+    litargs = {}
+    if isinstance(litmodule, CLAYModule):
+        litargs = {"output_patch_embeddings": output_patch_embeddings}
+    model: L.LightningModule = litmodule(**litargs)
 
     # Run tests in a temporary folder
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -100,9 +100,14 @@ def test_model_predict(datapipe, litmodule, precision, output_patch_embeddings):
     dataloader = torchdata.dataloader2.DataLoader2(datapipe=datapipe)
 
     # Initialize model
-    litargs = {}
-    if isinstance(litmodule, CLAYModule):
-        litargs = {"output_patch_embeddings": output_patch_embeddings}
+    if litmodule == CLAYModule:
+        litargs = {
+            "output_patch_embeddings": output_patch_embeddings,
+            "shuffle": False,
+        }
+    else:
+        litargs = {}
+
     model: L.LightningModule = litmodule(**litargs)
 
     # Run tests in a temporary folder
@@ -146,7 +151,7 @@ def test_model_predict(datapipe, litmodule, precision, output_patch_embeddings):
         for embeddings in geodataframe.embeddings:
             assert (
                 embeddings.shape == (16 * 16 * 768,)
-                if output_patch_embeddings
+                if output_patch_embeddings and litmodule == CLAYModule
                 else (768,)
             )
             assert embeddings.dtype == "float32"

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -103,7 +103,6 @@ def test_model_predict(datapipe, litmodule, precision, embeddings_level):
     if litmodule == CLAYModule:
         litargs = {
             "embeddings_level": embeddings_level,
-            "shuffle": False,
         }
     else:
         litargs = {}

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -91,7 +91,14 @@ def test_model_vit_fit(datapipe):
         (ViTLitModule, "bf16-mixed"),
     ],
 )
-def test_model_predict(datapipe, litmodule, precision):
+@pytest.mark.parametrize(
+    "litmodule,output_patch_embeddings",
+    [
+        (CLAYModule, True),
+        (CLAYModule, False),
+    ],
+)
+def test_model_predict(datapipe, litmodule, precision, output_patch_embeddings):
     """
     Run a single prediction loop using 1 batch.
     """
@@ -140,6 +147,10 @@ def test_model_predict(datapipe, litmodule, precision):
         assert geodataframe.geometry.dtype == gpd.array.GeometryDtype()
 
         for embeddings in geodataframe.embeddings:
-            assert embeddings.shape == (768,)
+            assert (
+                embeddings.shape == (16 * 16 * 768,)
+                if output_patch_embeddings
+                else (768,)
+            )
             assert embeddings.dtype == "float32"
             assert not np.isnan(embeddings).any()


### PR DESCRIPTION
This PR adds an option to the Lightning CLI to output patch level embeddings. I.e. one embedding per patch in each chip. The band group dimension is reduced and, so the patch embeddings are averages over the band groups.

This adds two args to the CLI `output_patch_embeddings`, and `shuffle`. Because for the patch embeddings we need to ensure that shuffle is off, while it is on by default. See also https://github.com/Clay-foundation/model/issues/123.

Updated the documentation to explain these changes.

This PR Closes https://github.com/Clay-foundation/model/issues/130