### PR TITLE
Memory buildup clean

### DIFF
--- a/src/callbacks_wandb.py
+++ b/src/callbacks_wandb.py
@@ -235,3 +235,4 @@ class LogIntermediatePredictions(L.Callback):
                 axs[1, i].axis("off")
 
             self.logger.experiment.log({"Images": wandb.Image(fig)})
+            plt.close('all')

--- a/src/callbacks_wandb.py
+++ b/src/callbacks_wandb.py
@@ -235,4 +235,4 @@ class LogIntermediatePredictions(L.Callback):
                 axs[1, i].axis("off")
 
             self.logger.experiment.log({"Images": wandb.Image(fig)})
-            plt.close('all')
+            plt.close("all")

--- a/src/callbacks_wandb.py
+++ b/src/callbacks_wandb.py
@@ -235,4 +235,4 @@ class LogIntermediatePredictions(L.Callback):
                 axs[1, i].axis("off")
 
             self.logger.experiment.log({"Images": wandb.Image(fig)})
-            plt.close("all")
+            plt.close(fig)

--- a/trainer.py
+++ b/trainer.py
@@ -9,6 +9,7 @@ References:
 - https://lightning.ai/docs/pytorch/2.1.0/cli/lightning_cli.html
 - https://pytorch-lightning.medium.com/introducing-lightningcli-v2-supercharge-your-training-c070d43c7dd6
 """
+
 from lightning.pytorch.callbacks import (
     LearningRateMonitor,  # noqa: F401
     ModelCheckpoint,
@@ -24,8 +25,6 @@ from src.callbacks_wandb import (  # noqa: F401
 from src.datamodule import ClayDataModule, GeoTIFFDataPipeModule  # noqa: F401
 from src.model_clay import CLAYModule
 from src.model_vit import ViTLitModule  # noqa: F401
-import tracemalloc
-
 
 
 # %%
@@ -74,16 +73,14 @@ def cli_main(
     return cli
 
 
-
-
 # %%
 if __name__ == "__main__":
-    #tracemalloc.start()
+    # tracemalloc.start()
     cli_main()
-    
-    #snapshot = tracemalloc.take_snapshot()
-    #top_stats = snapshot.statistics('lineno')
-    #print("[ Top 10 ]")
-    #for stat in top_stats[:10]:
+
+    # snapshot = tracemalloc.take_snapshot()
+    # top_stats = snapshot.statistics('lineno')
+    # print("[ Top 10 ]")
+    # for stat in top_stats[:10]:
     #    print(stat)
     print("Done!")

--- a/trainer.py
+++ b/trainer.py
@@ -26,6 +26,7 @@ from src.datamodule import ClayDataModule, GeoTIFFDataPipeModule  # noqa: F401
 from src.model_clay import CLAYModule
 from src.model_vit import ViTLitModule  # noqa: F401
 
+
 # %%
 def cli_main(
     save_config_callback=None,

--- a/trainer.py
+++ b/trainer.py
@@ -24,6 +24,8 @@ from src.callbacks_wandb import (  # noqa: F401
 from src.datamodule import ClayDataModule, GeoTIFFDataPipeModule  # noqa: F401
 from src.model_clay import CLAYModule
 from src.model_vit import ViTLitModule  # noqa: F401
+import tracemalloc
+
 
 
 # %%
@@ -72,7 +74,16 @@ def cli_main(
     return cli
 
 
+
+
 # %%
 if __name__ == "__main__":
+    #tracemalloc.start()
     cli_main()
+    
+    #snapshot = tracemalloc.take_snapshot()
+    #top_stats = snapshot.statistics('lineno')
+    #print("[ Top 10 ]")
+    #for stat in top_stats[:10]:
+    #    print(stat)
     print("Done!")

--- a/trainer.py
+++ b/trainer.py
@@ -26,7 +26,6 @@ from src.datamodule import ClayDataModule, GeoTIFFDataPipeModule  # noqa: F401
 from src.model_clay import CLAYModule
 from src.model_vit import ViTLitModule  # noqa: F401
 
-
 # %%
 def cli_main(
     save_config_callback=None,
@@ -75,12 +74,6 @@ def cli_main(
 
 # %%
 if __name__ == "__main__":
-    # tracemalloc.start()
     cli_main()
 
-    # snapshot = tracemalloc.take_snapshot()
-    # top_stats = snapshot.statistics('lineno')
-    # print("[ Top 10 ]")
-    # for stat in top_stats[:10]:
-    #    print(stat)
     print("Done!")


### PR DESCRIPTION
fixes #157.

Using malloc I tested that the biggest mem footprint buildup after n epochs is from matplotlib, which we use on wandb plots. 

Just closing the plot frees most of the buildup.

```logs
1 epochs 
matplotlib/cbook.py:733: size=32.0 MiB, count=66, average=497 KiB
<frozen importlib._bootstrap_external>:729: size=2997 KiB, count=27469, average=112 B
matplotlib/transforms.py:198: size=1515 KiB, count=16624, average=93 B
matplotlib/lines.py:359: size=1336 KiB, count=1728, average=792 B

100 epochs before fix
matplotlib/cbook.py:733: size=1616 MiB, count=3333, average=497 KiB
matplotlib/transforms.py:198: size=74.7 MiB, count=839610, average=93 B
matplotlib/lines.py:359: size=65.9 MiB, count=87264, average=792 B
matplotlib/text.py:994: size=61.0 MiB, count=80800, average=792 B

100 epochs clearing "all" plots
matplotlib/cbook.py:733: size=64.0 MiB, count=132, average=497 KiB
matplotlib/transforms.py:198: size=3031 KiB, count=33252, average=93 B
<frozen importlib._bootstrap_external>:729: size=2995 KiB, count=27459, average=112 B
matplotlib/lines.py:359: size=2673 KiB, count=3456, average=792 B

100 epochs clearing fig plot
matplotlib/cbook.py:733: size=32.0 MiB, count=66, average=497 KiB
<frozen importlib._bootstrap_external>:729: size=2988 KiB, count=27324, average=112 B
matplotlib/transforms.py:198: size=1515 KiB, count=16626, average=93 B
matplotlib/lines.py:359: size=1336 KiB, count=1728, average=792 B

```

I left the malloc code commented out to make it easer in the future if needed.