### PR TITLE
Create data/minicubes directory if it doesn't already exist

### DIFF
--- a/docs/partial-inputs-flood-tutorial.ipynb
+++ b/docs/partial-inputs-flood-tutorial.ipynb
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "outdir = Path(\"data/minicubes\")\n",
-    "assert outdir.exists()\n",
+    "outdir.mkdir(exist_ok=True, parents=True)\n",
     "\n",
     "# Write tile to output dir\n",
     "for tile in stack:\n",

--- a/docs/partial-inputs-flood-tutorial.ipynb
+++ b/docs/partial-inputs-flood-tutorial.ipynb
@@ -303,8 +303,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_DIR = \"/home/ubuntu/data/minicubes\"\n",
-    "CKPT_PATH = \"https://huggingface.co/made-with-clay/Clay1/resolve/main/Clay_v0.1_epoch-24_val-loss-0.46.ckpt\"\n",
+    "DATA_DIR = \"data/minicubes\"\n",
+    "CKPT_PATH = \"https://huggingface.co/made-with-clay/Clay/resolve/main/Clay_v0.1_epoch-24_val-loss-0.46.ckpt\"\n",
     "\n",
     "# Load model\n",
     "multi_model = CLAYModule.load_from_checkpoint(\n",

--- a/docs/partial-inputs.ipynb
+++ b/docs/partial-inputs.ipynb
@@ -204,7 +204,7 @@
    "outputs": [],
    "source": [
     "outdir = Path(\"data/minicubes\")\n",
-    "outdir.mkdir(exist_ok=True)\n",
+    "outdir.mkdir(exist_ok=True, parents=True)\n",
     "\n",
     "# Write tile to output dir\n",
     "for tile in stack:\n",

--- a/docs/partial-inputs.ipynb
+++ b/docs/partial-inputs.ipynb
@@ -204,7 +204,7 @@
    "outputs": [],
    "source": [
     "outdir = Path(\"data/minicubes\")\n",
-    "assert outdir.exists()\n",
+    "outdir.mkdir(exist_ok=True)\n",
     "\n",
     "# Write tile to output dir\n",
     "for tile in stack:\n",

--- a/docs/partial-inputs.ipynb
+++ b/docs/partial-inputs.ipynb
@@ -265,7 +265,7 @@
    ],
    "source": [
     "DATA_DIR = \"data/minicubes\"\n",
-    "CKPT_PATH = \"https://huggingface.co/made-with-clay/Clay1/resolve/main/Clay_v0.1_epoch-24_val-loss-0.46.ckpt\"\n",
+    "CKPT_PATH = \"https://huggingface.co/made-with-clay/Clay/resolve/main/Clay_v0.1_epoch-24_val-loss-0.46.ckpt\"\n",
     "\n",
     "# Load model\n",
     "rgb_model = CLAYModule.load_from_checkpoint(\n",


### PR DESCRIPTION
Prevents an AssertionError on the partial-inputs jupyter notebook when the `data/minicubes` folder doesn't exist, by just creating the folder!

Patches #149