### PR TITLE
Add osx platform to conda lock file and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
     defaults:
       run:
         shell: bash -l {0}

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -14,11 +14,13 @@ version: 1
 metadata:
   content_hash:
     linux-64: 6ac7b705a1a6d1693bc0579616f8041fa2997cf3f7697434ed18493358be7c3d
+    osx-64: 7f58e3b3c444a6ab5c2e132b74a076b890007f5d704b8bf2dd142758d9ddbc7e
   channels:
   - url: conda-forge
     used_env_vars: []
   platforms:
   - linux-64
+  - osx-64
   sources:
   - environment.yml
 package:
@@ -59,10 +61,35 @@ package:
     sha256: ce532e2da08fb2b77df281e3d42e2b2131641bdd6a6e8127f3718ae6860bd70d
   category: main
   optional: false
+- name: accessible-pygments
+  version: 0.0.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pygments: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 46a2e6e3dfa718ce3492018d5a110dd6
+    sha256: ce532e2da08fb2b77df281e3d42e2b2131641bdd6a6e8127f3718ae6860bd70d
+  category: main
+  optional: false
 - name: affine
   version: 2.4.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ae5f4ad87126c55ba3f690ef07f81d64
+    sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  category: main
+  optional: false
+- name: affine
+  version: 2.4.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
@@ -90,10 +117,41 @@ package:
     sha256: 7a1eab2665769eac070849f31517af94b047b8b765cd16ce5cdcf7073750c435
   category: main
   optional: false
+- name: aiohttp
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    yarl: '>=1.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.9.3-py311he705e18_0.conda
+  hash:
+    md5: a6f50a0875caca10dbc385b946d82a9c
+    sha256: 7f013f12311881c8fb849df233b8402feef76f212d46e8ead9f0622a53d98b9a
+  category: main
+  optional: false
 - name: aiosignal
   version: 1.3.1
   manager: conda
   platform: linux-64
+  dependencies:
+    frozenlist: '>=1.1.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d1e1eb7e21a9e2c74279d87dafb68156
+    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
   dependencies:
     frozenlist: '>=1.1.0'
     python: '>=3.7'
@@ -115,10 +173,38 @@ package:
     sha256: fd39ad2fabec1569bbb0dfdae34ab6ce7de6ec09dcec8638f83dad0373594069
   category: main
   optional: false
+- name: alabaster
+  version: 0.7.16
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.16-pyhd8ed1ab_0.conda
+  hash:
+    md5: def531a3ac77b7fb8c21d17bb5d0badb
+    sha256: fd39ad2fabec1569bbb0dfdae34ab6ce7de6ec09dcec8638f83dad0373594069
+  category: main
+  optional: false
 - name: anyio
   version: 4.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ac95aa8ed65adfdde51132595c79aade
+    sha256: 86aca4a31c09f9b4dbdb332cd9a6a7dbab62ca734d3f832651c0ab59c6a7f52e
+  category: main
+  optional: false
+- name: anyio
+  version: 4.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
@@ -144,6 +230,18 @@ package:
     sha256: 42fd8fc28735deac6c578c9a07fc4c6b1912ba4300b63631e64fc0a6e0f22370
   category: main
   optional: false
+- name: aom
+  version: 3.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.1-h73e2aa4_0.conda
+  hash:
+    md5: 3194f8209de31e1e09f2ae915c5288d4
+    sha256: ee8677cc9bea352c7fe12d5f42f0d277cee1d7e7f5518ae728dc1befc75fe49a
+  category: main
+  optional: false
 - name: appdirs
   version: 1.4.4
   manager: conda
@@ -154,6 +252,30 @@ package:
   hash:
     md5: 5f095bc6454094e96f146491fd03633b
     sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  category: main
+  optional: false
+- name: appdirs
+  version: 1.4.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 5f095bc6454094e96f146491fd03633b
+    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  category: main
+  optional: false
+- name: appnope
+  version: 0.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: cc4834a9ee7cc49ce8d25177c47b10d8
+    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
   category: main
   optional: false
 - name: argcomplete
@@ -168,10 +290,36 @@ package:
     sha256: 8a1d1f92d40c6686d10ecce290a42560d023ecc02676f54dcfedfc0ede354f52
   category: main
   optional: false
+- name: argcomplete
+  version: 3.2.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4017741f57d9bbf3cf184ca147859f78
+    sha256: 8a1d1f92d40c6686d10ecce290a42560d023ecc02676f54dcfedfc0ede354f52
+  category: main
+  optional: false
 - name: argon2-cffi
   version: 23.1.0
   manager: conda
   platform: linux-64
+  dependencies:
+    argon2-cffi-bindings: ''
+    python: '>=3.7'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  category: main
+  optional: false
+- name: argon2-cffi
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
   dependencies:
     argon2-cffi-bindings: ''
     python: '>=3.7'
@@ -197,10 +345,38 @@ package:
     sha256: 104194af519b4e667aa5341068b94b521a791aaaa05ec0091f8f0bdba43a60ac
   category: main
   optional: false
+- name: argon2-cffi-bindings
+  version: 21.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cffi: '>=1.0.1'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h2725bcf_4.conda
+  hash:
+    md5: e2aba0ad0f533ee73f9d4330d2e32549
+    sha256: be27659496bcb660fc9c3f5f74128a7bb090336897e9c7cfbcc55ae66f13b8d8
+  category: main
+  optional: false
 - name: arrow
   version: 1.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  category: main
+  optional: false
+- name: arrow
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     python-dateutil: '>=2.7.0'
@@ -223,10 +399,35 @@ package:
     sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
   category: main
   optional: false
+- name: asciitree
+  version: 0.3.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  hash:
+    md5: c0481c9de49f040272556e2cedf42816
+    sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  category: main
+  optional: false
 - name: asttokens
   version: 2.4.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5f25798dcefd8252ce5f9dc494d5f571
+    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  category: main
+  optional: false
+- name: asttokens
+  version: 2.4.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
     six: '>=1.12.0'
@@ -249,10 +450,35 @@ package:
     sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   category: main
   optional: false
+- name: async-lru
+  version: 2.0.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  category: main
+  optional: false
 - name: attrs
   version: 23.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+  hash:
+    md5: 5e4c0743c70186509d1412e03c2d8dfa
+    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+  category: main
+  optional: false
+- name: attrs
+  version: 23.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
@@ -278,6 +504,22 @@ package:
     sha256: ef98131dbff55f482b0af10d17aa6c478e59987661cf3c22dddb30a441986aa5
   category: main
   optional: false
+- name: aws-c-auth
+  version: 0.7.11
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-c-sdkutils: '>=0.1.13,<0.1.14.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.11-h94c8779_1.conda
+  hash:
+    md5: 0c504fbf22cf8560e4cbe1a68d71bace
+    sha256: 2aa423f5c64c4df7a8a2d9b4f7fa915c4a7d6e01a018f04fbf4c4bd9b699ea50
+  category: main
+  optional: false
 - name: aws-c-cal
   version: 0.6.9
   manager: conda
@@ -292,6 +534,18 @@ package:
     sha256: d4f593f586378d7544900847b16d922a10c4d92aec7add6e3cb5dbe69965ab2f
   category: main
   optional: false
+- name: aws-c-cal
+  version: 0.6.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-he75d6b7_3.conda
+  hash:
+    md5: 56bca8b8f924ba21b26b9a0a158b93be
+    sha256: 772a3d9864658df5097c866633f14a78d88f21509157b09f9f8d6d0c04f09166
+  category: main
+  optional: false
 - name: aws-c-common
   version: 0.9.12
   manager: conda
@@ -302,6 +556,17 @@ package:
   hash:
     md5: 7dbb94ffb9df66406f3101625807cac1
     sha256: 22e7c9438f2fe3c46a1747efcaae4ab3a078714ff8992a6ec3c213f50b9d6704
+  category: main
+  optional: false
+- name: aws-c-common
+  version: 0.9.12
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.12-h10d778d_0.conda
+  hash:
+    md5: d04b9a72861e43eb78e0c133056e1655
+    sha256: 21171720a36e233246ce9fa602b124b2fb4fffe97b906fa58bf7603d1af93789
   category: main
   optional: false
 - name: aws-c-compression
@@ -315,6 +580,18 @@ package:
   hash:
     md5: cc6630010cb1211cc15fb348f7c7eb70
     sha256: 0627434bcee61f94cf35d7719a395d4b7c9967f20bb877f1bd05868013a8a93c
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.2.17
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h45babc2_8.conda
+  hash:
+    md5: 3b63d41977e0e390e42446372f5f1b03
+    sha256: 19d3fb58b89ad3c1a2693ea81f98bca51843c7cdec7afaebc96b5013d73b2a91
   category: main
   optional: false
 - name: aws-c-event-stream
@@ -333,6 +610,21 @@ package:
     sha256: a7cb50ccb2779d2934cae3a4fcc3d032a4525b63a464d6bd23957650381d633e
   category: main
   optional: false
+- name: aws-c-event-stream
+  version: 0.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h3600a39_2.conda
+  hash:
+    md5: d15584e342a31e978262627e6fd4063b
+    sha256: ef306832c033c46ab4b434ebf6e0a53a0f1a5023d6dbd6d31b90c2deea997a6c
+  category: main
+  optional: false
 - name: aws-c-http
   version: 0.8.0
   manager: conda
@@ -347,6 +639,21 @@ package:
   hash:
     md5: ec632590307b47ac47d22ebcf91f4043
     sha256: 5929ac8e3118146f9d23a5fdff54e2025501ee20a2cd9d8dd2b0115a60442dce
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h19e0e28_2.conda
+  hash:
+    md5: 0714dff2eee274db27ad65d82b61374d
+    sha256: f6de21c9ade6ac83b418a5277025b9a0ec55fdcb9c34f8cf3a595122b9b5e43f
   category: main
   optional: false
 - name: aws-c-io
@@ -364,6 +671,19 @@ package:
     sha256: dd52e17a5be987b384c62574d90ddafbba68fa65b1f1344236b90c50ffed304d
   category: main
   optional: false
+- name: aws-c-io
+  version: 0.14.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.0-h49ca7b5_1.conda
+  hash:
+    md5: f276e1df52ac6d261e5fa7e85d8cb02f
+    sha256: 27d102f01cc662f703ecc7cff9350526587e6fc57347ddc6d3df8db569b2e19b
+  category: main
+  optional: false
 - name: aws-c-mqtt
   version: 0.10.1
   manager: conda
@@ -377,6 +697,20 @@ package:
   hash:
     md5: 4cba7afc0f74a7cce3159c0bceb607c3
     sha256: 8edcb09a2d93c24320f517f837a0e46e98749b72dc7c9d55ce1fa0c4fa5db116
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-h947eb33_0.conda
+  hash:
+    md5: 572658337a20c3a1e6ecf59f610be930
+    sha256: 0f9a6de491c1c61ed1635a2814d6be52f041f2bf393c04a85a1da13ee862c90b
   category: main
   optional: false
 - name: aws-c-s3
@@ -398,6 +732,23 @@ package:
     sha256: b10ad88a1b1f7bf8bb999e06b4bb92e87fa9ede81a10492a373d354f4276a77b
   category: main
   optional: false
+- name: aws-c-s3
+  version: 0.4.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-auth: '>=0.7.11,<0.7.12.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.9-hee0ca28_0.conda
+  hash:
+    md5: b3d80d5c3ff89a4e04799caf71e8ec41
+    sha256: 4d85b122da9250ad318922e09e63f2ed9efb2c394c9c5e38bcdc38a534f6db1a
+  category: main
+  optional: false
 - name: aws-c-sdkutils
   version: 0.1.13
   manager: conda
@@ -411,6 +762,18 @@ package:
     sha256: eb54d7573f9bbd1d01458203dd83e9c0c94c73be91af9142dd78e1a928be5b7e
   category: main
   optional: false
+- name: aws-c-sdkutils
+  version: 0.1.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-h45babc2_1.conda
+  hash:
+    md5: 4fd7f6b8225feb707d401eb18bfc0b2a
+    sha256: f780e3d3de1a4111b63ee7fad24046e2618c4086fcbdebca5cb75469fc7abfda
+  category: main
+  optional: false
 - name: aws-checksums
   version: 0.1.17
   manager: conda
@@ -422,6 +785,18 @@ package:
   hash:
     md5: f7323eedc2685a24661cd6b57d7ed321
     sha256: c29ca126f9dd520cc749e8cb99b07168badb333b4b1b95577bb1788c432fe2d0
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.17
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h45babc2_7.conda
+  hash:
+    md5: 356e6abc54e4a2e26027d179ddad29ce
+    sha256: 9f6e240ce66f3d120b6bc7d6ac9f3625c039a2f0b4132479ccc9798d08200e8f
   category: main
   optional: false
 - name: aws-crt-cpp
@@ -446,6 +821,27 @@ package:
     sha256: 4bdef70ff6362d8a3350b4c4181d078e7b1f654a249d63294e9ab1c5a9ca72c7
   category: main
   optional: false
+- name: aws-crt-cpp
+  version: 0.26.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-auth: '>=0.7.11,<0.7.12.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
+    aws-c-http: '>=0.8.0,<0.8.1.0a0'
+    aws-c-io: '>=0.14.0,<0.14.1.0a0'
+    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
+    aws-c-s3: '>=0.4.9,<0.4.10.0a0'
+    aws-c-sdkutils: '>=0.1.13,<0.1.14.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-he4637c3_8.conda
+  hash:
+    md5: 47d83636ee8f3876199ad1c3bf32a5b3
+    sha256: 1eaea1b9e4ce6e39ffbdc9533e5f738d01b88b3219cb6a583d8a270a923abaec
+  category: main
+  optional: false
 - name: aws-sdk-cpp
   version: 1.11.210
   manager: conda
@@ -466,6 +862,25 @@ package:
     sha256: 97b50927c4312ad80f3729669fa8b55195c066710e0af73c818c244df01b7604
   category: main
   optional: false
+- name: aws-sdk-cpp
+  version: 1.11.210
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    aws-crt-cpp: '>=0.26.0,<0.26.1.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-hf51409f_10.conda
+  hash:
+    md5: 10d6bd28caf5b216b9042d3fd891fab4
+    sha256: fd4ff9b0422d104bde364fb0dc27f85eb64adce03fc866315120493e9409a64a
+  category: main
+  optional: false
 - name: azure-core-cpp
   version: 1.10.3
   manager: conda
@@ -481,6 +896,20 @@ package:
     sha256: 8740ccf0a22b13ddc7e6b0b577398fc3ec82aa8e020428aa13d69cf4c02bd0b6
   category: main
   optional: false
+- name: azure-core-cpp
+  version: 1.10.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.10.3-hbb1e571_1.conda
+  hash:
+    md5: 9c258c44761c173f7b21b4375a459496
+    sha256: 9dd27a9a321ec113cd52f7e2cee268c44e31b7ce1963d34d9623d2119215652e
+  category: main
+  optional: false
 - name: azure-storage-blobs-cpp
   version: 12.10.0
   manager: conda
@@ -494,6 +923,21 @@ package:
   hash:
     md5: 64eec459779f01803594f5272cdde23c
     sha256: ea323e7028590b1877af92b76bc3cda52db5a1d90b8321ec91b9db0689f07fb3
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    azure-core-cpp: '>=1.10.3,<2.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-he51d815_0.conda
+  hash:
+    md5: 49b100390f08fbbf2219b4e220f79983
+    sha256: 2b20c7884bebc511a7433802a81b7fc95a9aae957a760779a1699f087ffdf018
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -512,10 +956,40 @@ package:
     sha256: 68e177ae983d63323b9bd1c1528776bb0e03d5d5aef0addba97aed4537e649a6
   category: main
   optional: false
+- name: azure-storage-common-cpp
+  version: 12.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    azure-core-cpp: '>=1.10.3,<2.0a0'
+    libcxx: '>=16.0.6'
+    libxml2: '>=2.12.1,<3.0.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-hf4badfb_2.conda
+  hash:
+    md5: 277020b2f0245d1d5a0a3bb0e921c069
+    sha256: b9336e9cbbf7a26f5cfab7dca2aec8037549efe8c8d6022e07b38f8840bbc608
+  category: main
+  optional: false
 - name: babel
   version: 2.14.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    pytz: ''
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9669586875baeced8fc30c0826c3270e
+    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
+  category: main
+  optional: false
+- name: babel
+  version: 2.14.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     pytz: ''
@@ -539,10 +1013,39 @@ package:
     sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
   category: main
   optional: false
+- name: beautifulsoup4
+  version: 4.12.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    soupsieve: '>=1.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  hash:
+    md5: 332493000404d8411859539a5a630865
+    sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  category: main
+  optional: false
 - name: bleach
   version: 6.1.0
   manager: conda
   platform: linux-64
+  dependencies:
+    packaging: ''
+    python: '>=3.6'
+    setuptools: ''
+    six: '>=1.9.0'
+    webencodings: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  category: main
+  optional: false
+- name: bleach
+  version: 6.1.0
+  manager: conda
+  platform: osx-64
   dependencies:
     packaging: ''
     python: '>=3.6'
@@ -572,6 +1075,22 @@ package:
     sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
   category: main
   optional: false
+- name: blosc
+  version: 1.21.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+  hash:
+    md5: 3003fa6dd18769db1a616982dcee5b40
+    sha256: db629047f1721d5a6e3bd41b07c1a3bacd0dee70f4063b61db2aa46f19a0b8b4
+  category: main
+  optional: false
 - name: brotli
   version: 1.1.0
   manager: conda
@@ -587,6 +1106,20 @@ package:
     sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
   category: main
   optional: false
+- name: brotli
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli-bin: 1.1.0
+    libbrotlidec: 1.1.0
+    libbrotlienc: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9272dd3b19c4e8212f8542cefd5c3d67
+    sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
+  category: main
+  optional: false
 - name: brotli-bin
   version: 1.1.0
   manager: conda
@@ -599,6 +1132,19 @@ package:
   hash:
     md5: 39f910d205726805a958da408ca194ba
     sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+  category: main
+  optional: false
+- name: brotli-bin
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlidec: 1.1.0
+    libbrotlienc: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: ece565c215adcc47fc1db4e651ee094b
+    sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
   category: main
   optional: false
 - name: brotli-python
@@ -616,6 +1162,20 @@ package:
     sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
   category: main
   optional: false
+- name: brotli-python
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
+  hash:
+    md5: 546fdccabb90492fbaf2da4ffb78f352
+    sha256: 0f5e0a7de58006f349220365e32db521a1fe494c37ee455e5ecf05b8fe567dcc
+  category: main
+  optional: false
 - name: brunsli
   version: '0.1'
   manager: conda
@@ -630,6 +1190,19 @@ package:
     sha256: 36da32e5a6beab7a9af39be1c8f42e5eca716e64562cb9d5e0d559c14406b11d
   category: main
   optional: false
+- name: brunsli
+  version: '0.1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli: '>=1.0.9,<2.0a0'
+    libcxx: '>=11.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/brunsli-0.1-h046ec9c_0.tar.bz2
+  hash:
+    md5: 28d47920c95b85499c9a61994cc49b87
+    sha256: e9abc53437889e03013b466521f928903fa27de770d16eb5f4ac6c4266a7b6a4
+  category: main
+  optional: false
 - name: bzip2
   version: 1.0.8
   manager: conda
@@ -642,16 +1215,38 @@ package:
     sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
   category: main
   optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+  hash:
+    md5: 6097a6ca9ada32699b5fc4312dd6ef18
+    sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+  category: main
+  optional: false
 - name: c-ares
-  version: 1.26.0
+  version: 1.27.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
   hash:
-    md5: a86d90025198fd411845fc245ebc06c8
-    sha256: 3771589a91303710a59d1d40bbcdca43743969fe993ea576538ba375ac8ab0fa
+    md5: f6afff0e9ee08d2f1b897881a4f38cdb
+    sha256: 2a5866b19d28cb963fab291a62ff1c884291b9d6f59de14643e52f103e255749
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.27.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.27.0-h10d778d_0.conda
+  hash:
+    md5: 713dd57081dfe8535eb961b45ed26a0c
+    sha256: a53e14c071dcce756ce80673f2a90a1c6dff695a26bc9f5e54d56b55e76ee3dc
   category: main
   optional: false
 - name: c-blosc2
@@ -670,6 +1265,21 @@ package:
     sha256: 525647593115f5feb8c82c227803bb84d65307756a19e755512931dc6e8c9ff3
   category: main
   optional: false
+- name: c-blosc2
+  version: 2.13.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    zlib-ng: '>=2.0.7,<2.1.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.13.2-h0ae8482_0.conda
+  hash:
+    md5: 315eed7dfde8aedb6169e516df757d52
+    sha256: 25082a287fce5e5ff183d398448eb9f5ac458dcbf532cfa2634bbd4f7f46b6c7
+  category: main
+  optional: false
 - name: ca-certificates
   version: 2024.2.2
   manager: conda
@@ -681,10 +1291,35 @@ package:
     sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
   category: main
   optional: false
+- name: ca-certificates
+  version: 2024.2.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+  hash:
+    md5: f2eacee8c33c43692f1ccfd33d0f50b1
+    sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
+  category: main
+  optional: false
 - name: cachecontrol
   version: 0.14.0
   manager: conda
   platform: linux-64
+  dependencies:
+    msgpack-python: '>=0.5.2'
+    python: '>=3.7'
+    requests: '>=2.16.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a661c39e223bf3038b38126b0bbf43d9
+    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
+  category: main
+  optional: false
+- name: cachecontrol
+  version: 0.14.0
+  manager: conda
+  platform: osx-64
   dependencies:
     msgpack-python: '>=0.5.2'
     python: '>=3.7'
@@ -709,10 +1344,36 @@ package:
     sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
   category: main
   optional: false
+- name: cachecontrol-with-filecache
+  version: 0.14.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
+    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
+  category: main
+  optional: false
 - name: cached-property
   version: 1.5.2
   manager: conda
   platform: linux-64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  category: main
+  optional: false
+- name: cached-property
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
   dependencies:
     cached_property: '>=1.5.2,<1.5.3.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -733,10 +1394,34 @@ package:
     sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
   category: main
   optional: false
+- name: cached_property
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  category: main
+  optional: false
 - name: cachy
   version: 0.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: 5dfee17f24e2dfd18d7392b48c9351e2
+    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
+  category: main
+  optional: false
+- name: cachy
+  version: 0.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
@@ -773,10 +1458,44 @@ package:
     sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
   category: main
   optional: false
+- name: cairo
+  version: 1.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libcxx: '>=16.0.6'
+    libglib: '>=2.78.0,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pixman: '>=0.42.2,<1.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+  hash:
+    md5: 13f830b1bf46018f7062d1b798d53eca
+    sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
+  category: main
+  optional: false
 - name: certifi
   version: 2024.2.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0876280e409658fc6f9e75d035960333
+    sha256: f1faca020f988696e6b6ee47c82524c7806380b37cfdd1def32f92c326caca54
+  category: main
+  optional: false
+- name: certifi
+  version: 2024.2.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
@@ -801,6 +1520,21 @@ package:
     sha256: b71c94528ca0c35133da4b7ef69b51a0b55eeee570376057f3d2ad60c3ab1444
   category: main
   optional: false
+- name: cffi
+  version: 1.16.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pycparser: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
+  hash:
+    md5: 15d07b82223cac96af629e5e747ba27a
+    sha256: 1f13a5fa7f310fdbd27f5eddceb9e62cfb10012c58a58c923dd6f51fa979748a
+  category: main
+  optional: false
 - name: cfitsio
   version: 4.3.1
   manager: conda
@@ -818,6 +1552,22 @@ package:
     sha256: b91003bff71351a0132c84d69fbb5afcfa90e57d83f76a180c6a5a0289099fb1
   category: main
   optional: false
+- name: cfitsio
+  version: 4.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.3.1-h60fb419_0.conda
+  hash:
+    md5: 03ab895afe3804b527c12193a9612cac
+    sha256: 5bd157478529ff4d05b8e8654de0580609177252eb11ecf5201b831effeeb2ec
+  category: main
+  optional: false
 - name: charls
   version: 2.4.2
   manager: conda
@@ -829,6 +1579,18 @@ package:
   hash:
     md5: 4336bd67920dd504cd8c6761d6a99645
     sha256: 18f1c43f91ccf28297f92b094c2c8dbe9c6e8241c0d3cbd6cda014a990660fdd
+  category: main
+  optional: false
+- name: charls
+  version: 2.4.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/charls-2.4.2-he965462_0.conda
+  hash:
+    md5: c267b3955138953f8ca4cb4d1f4f2d84
+    sha256: 5167aafc0bcc3849373dd8afb448cc387078210236e597f2ef8d2b1fe3d0b1a2
   category: main
   optional: false
 - name: charset-normalizer
@@ -843,10 +1605,35 @@ package:
     sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
   category: main
   optional: false
+- name: charset-normalizer
+  version: 3.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7f4a9e3fcff3f6356ae99244a014da6a
+    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  category: main
+  optional: false
 - name: click
   version: 8.1.7
   manager: conda
   platform: linux-64
+  dependencies:
+    __unix: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  hash:
+    md5: f3ad426304898027fc619827ff428eca
+    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  category: main
+  optional: false
+- name: click
+  version: 8.1.7
+  manager: conda
+  platform: osx-64
   dependencies:
     __unix: ''
     python: '>=3.8'
@@ -869,6 +1656,19 @@ package:
     sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
   category: main
   optional: false
+- name: click-default-group
+  version: 1.2.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2b6931f9b3548ed78478332095c3e9
+    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+  category: main
+  optional: false
 - name: click-plugins
   version: 1.1.1
   manager: conda
@@ -882,10 +1682,36 @@ package:
     sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
   category: main
   optional: false
+- name: click-plugins
+  version: 1.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=3.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  hash:
+    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  category: main
+  optional: false
 - name: cligj
   version: 0.7.2
   manager: conda
   platform: linux-64
+  dependencies:
+    click: '>=4.0'
+    python: <4.0
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: a29b7c141d6b2de4bb67788a5f107734
+    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  category: main
+  optional: false
+- name: cligj
+  version: 0.7.2
+  manager: conda
+  platform: osx-64
   dependencies:
     click: '>=4.0'
     python: <4.0
@@ -909,6 +1735,20 @@ package:
     sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
   category: main
   optional: false
+- name: clikit
+  version: 0.6.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+  hash:
+    md5: 02abb7b66b02e8b9f5a9b05454400087
+    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+  category: main
+  optional: false
 - name: cloudpickle
   version: 3.0.0
   manager: conda
@@ -921,10 +1761,34 @@ package:
     sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
   category: main
   optional: false
+- name: cloudpickle
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 753d29fe41bb881e4b9c004f0abf973f
+    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  category: main
+  optional: false
 - name: colorama
   version: 0.4.6
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3faab06a954c2a04039983f2c4a50d99
+    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  category: main
+  optional: false
+- name: colorama
+  version: 0.4.6
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
@@ -946,10 +1810,59 @@ package:
     sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
   category: main
   optional: false
+- name: comm
+  version: 0.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: f4385072f4909bc974f6675a36e76796
+    sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
+  category: main
+  optional: false
 - name: conda-lock
   version: 2.5.5
   manager: conda
   platform: linux-64
+  dependencies:
+    cachecontrol-with-filecache: '>=0.12.9'
+    cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
+    clikit: '>=0.6.2'
+    crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
+    pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
+    tomlkit: '>=0.7.0'
+    toolz: '>=0.12.0,<1.0.0'
+    typing_extensions: ''
+    urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 84e25a941be93fdf9838426825eb1481
+    sha256: f6b8c563c130f750a2838de8152e892cf75f4f77865d4de0295786c6aba5de84
+  category: main
+  optional: false
+- name: conda-lock
+  version: 2.5.5
+  manager: conda
+  platform: osx-64
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'
     cachy: '>=0.3.0'
@@ -998,10 +1911,38 @@ package:
     sha256: 2c76e2a970b74eef92ef9460aa705dbdc506dd59b7382bfbedce39d9c189d7f4
   category: main
   optional: false
+- name: contourpy
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    numpy: '>=1.20,<2'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.0-py311h7bea37d_0.conda
+  hash:
+    md5: 6711c052d956af4973a16749236a0387
+    sha256: 40bca4a644e0c0b0e6d58cef849ba02d4f218af715f7a5787d41845797f3b8a9
+  category: main
+  optional: false
 - name: crashtest
   version: 0.4.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 709a2295dd907bb34afb57d54320642f
+    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+  category: main
+  optional: false
+- name: crashtest
+  version: 0.4.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6,<4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
@@ -1124,6 +2065,18 @@ package:
     sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
+- name: cycler
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  category: main
+  optional: false
 - name: dask-core
   version: 2024.2.0
   manager: conda
@@ -1144,10 +2097,42 @@ package:
     sha256: 01e44a1d6d9ce227a9b513193f96e4cb07b950dd8365fbe105e5daf6224d25e8
   category: main
   optional: false
+- name: dask-core
+  version: 2024.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=8.1'
+    cloudpickle: '>=1.5.0'
+    fsspec: '>=2021.09.0'
+    importlib_metadata: '>=4.13.0'
+    packaging: '>=20.0'
+    partd: '>=1.2.0'
+    python: '>=3.9'
+    pyyaml: '>=5.3.1'
+    toolz: '>=0.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5973bc565e2aea620c3a431cafdde032
+    sha256: 01e44a1d6d9ce227a9b513193f96e4cb07b950dd8365fbe105e5daf6224d25e8
+  category: main
+  optional: false
 - name: dataclasses
   version: '0.8'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
+  hash:
+    md5: a362b2124b06aad102e2ee4581acee7d
+    sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
+  category: main
+  optional: false
+- name: dataclasses
+  version: '0.8'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
@@ -1183,6 +2168,33 @@ package:
     sha256: 6eba52c53088c7f8207ebb224393eea29a70bef1db28e2b794a7973d52284d23
   category: main
   optional: false
+- name: datasets
+  version: 2.14.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aiohttp: ''
+    dill: '>=0.3.0,<0.3.8'
+    fsspec: '>=2023.1.0,<=2023.10.0'
+    huggingface_hub: '>=0.14.0,<1.0.0'
+    importlib-metadata: ''
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=8.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
+    requests: '>=2.19.0'
+    tqdm: '>=4.62.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 13675409f6e4c17d539adb0f2aecc335
+    sha256: 6eba52c53088c7f8207ebb224393eea29a70bef1db28e2b794a7973d52284d23
+  category: main
+  optional: false
 - name: dav1d
   version: 1.2.1
   manager: conda
@@ -1193,6 +2205,17 @@ package:
   hash:
     md5: 418c6ca5929a611cbd69204907a83995
     sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  category: main
+  optional: false
+- name: dav1d
+  version: 1.2.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  hash:
+    md5: 9d88733c715300a39f8ca2e936b7808d
+    sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
   category: main
   optional: false
 - name: dbus
@@ -1224,10 +2247,36 @@ package:
     sha256: e69fe7d453389d54fa68fb6fb75ac85f882b2ab4bc745b02c7ff8cd83aee2a5b
   category: main
   optional: false
+- name: debugpy
+  version: 1.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.1-py311hdd0406b_0.conda
+  hash:
+    md5: 19779dab342c45f8acb28caa00b07637
+    sha256: 0df1ca336d468accadb2a1d617aac7c5a5c4c7d63d0d847ab237772f8ff1e93b
+  category: main
+  optional: false
 - name: decorator
   version: 5.1.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 43afe5ab04e35e17ba28649471dd7364
+    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  category: main
+  optional: false
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
@@ -1248,6 +2297,18 @@ package:
     sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   category: main
   optional: false
+- name: defusedxml
+  version: 0.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 961b3a227b437d82ad7054484cfa71b2
+    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  category: main
+  optional: false
 - name: dill
   version: 0.3.7
   manager: conda
@@ -1260,10 +2321,34 @@ package:
     sha256: 4ff20c6be028be2825235631c45d9e4a75bca1de65f8840c02dfb28ea0137c45
   category: main
   optional: false
+- name: dill
+  version: 0.3.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5e4f3466526c52bc9af2d2353a1460bd
+    sha256: 4ff20c6be028be2825235631c45d9e4a75bca1de65f8840c02dfb28ea0137c45
+  category: main
+  optional: false
 - name: distlib
   version: 0.3.8
   manager: conda
   platform: linux-64
+  dependencies:
+    python: 2.7|>=3.6
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+  category: main
+  optional: false
+- name: distlib
+  version: 0.3.8
+  manager: conda
+  platform: osx-64
   dependencies:
     python: 2.7|>=3.6
   url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
@@ -1285,6 +2370,19 @@ package:
     sha256: 2ba7e3e4f75e07b42246b4ba8569c983ecbdcda47b1b900632858a23d91826f2
   category: main
   optional: false
+- name: docker-pycreds
+  version: 0.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+    six: '>=1.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-pycreds-0.4.0-py_0.tar.bz2
+  hash:
+    md5: c69f19038efee4eb534623610d0c2053
+    sha256: 2ba7e3e4f75e07b42246b4ba8569c983ecbdcda47b1b900632858a23d91826f2
+  category: main
+  optional: false
 - name: docstring_parser
   version: '0.15'
   manager: conda
@@ -1297,23 +2395,60 @@ package:
     sha256: 9b22e1f1d0decc26cc0743ce929e1a7e233fd7921d1b5c390db0691b8042a706
   category: main
   optional: false
+- name: docstring_parser
+  version: '0.15'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.15-pyhd8ed1ab_0.conda
+  hash:
+    md5: 031fcb28b8e80c1f7bec22ccdf4904b2
+    sha256: 9b22e1f1d0decc26cc0743ce929e1a7e233fd7921d1b5c390db0691b8042a706
+  category: main
+  optional: false
 - name: docutils
-  version: 0.17.1
+  version: 0.20.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.17.1-py311h38be061_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
   hash:
-    md5: 6815ab599d904e21243aad721d0b2bbb
-    sha256: f8622b7ac95654b7a3236cd3fa9e07ab6121548e39713e55ee95fc64a8f1fab6
+    md5: 1c33f55e5cdcc2a2b973c432b5225bfe
+    sha256: 0011a2193a5995a6706936156ea5d1021153ec11eb8869b6abfe15a8f6f22ea8
+  category: main
+  optional: false
+- name: docutils
+  version: 0.20.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py311h6eed73b_3.conda
+  hash:
+    md5: 2919376c4957faadc7b96f8894759bfb
+    sha256: 0fae62e203900a8a013ba2ede852645b87b1568980ddd8e11390c11dc24c3e3c
   category: main
   optional: false
 - name: einops
   version: 0.7.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/einops-0.7.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 1641890c9375ddb22381f3eb9ac157df
+    sha256: cc08bb969a4458b7afd48e7ba8151c95b48f1c315d3567644ed4a97ee2987247
+  category: main
+  optional: false
+- name: einops
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/einops-0.7.0-pyhd8ed1ab_1.conda
@@ -1339,10 +2474,39 @@ package:
     sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
   category: main
   optional: false
+- name: ensureconda
+  version: 1.4.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    appdirs: ''
+    click: '>=5.1'
+    filelock: ''
+    packaging: ''
+    python: '>=3.7'
+    requests: '>=2'
+  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: e54a91c3a65491b13c68f7696425bac8
+    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
+  category: main
+  optional: false
 - name: entrypoints
   version: '0.4'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3cf04868fee0a029769bd41f4b2fbf2d
+    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  category: main
+  optional: false
+- name: entrypoints
+  version: '0.4'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
@@ -1363,10 +2527,34 @@ package:
     sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
   category: main
   optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
 - name: executing
   version: 2.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: e16be50e378d8a4533b989035b196ab8
+    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  category: main
+  optional: false
+- name: executing
+  version: 2.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2.7'
   url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
@@ -1388,6 +2576,18 @@ package:
     sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
   category: main
   optional: false
+- name: expat
+  version: 2.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libexpat: 2.5.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+  hash:
+    md5: e12630038077877cbb6c7851e139c17c
+    sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+  category: main
+  optional: false
 - name: fasteners
   version: 0.17.3
   manager: conda
@@ -1400,10 +2600,34 @@ package:
     sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
   category: main
   optional: false
+- name: fasteners
+  version: 0.17.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 348e27e78a5e39090031448c72f66d5e
+    sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  category: main
+  optional: false
 - name: filelock
   version: 3.13.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
+  category: main
+  optional: false
+- name: filelock
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
@@ -1437,10 +2661,45 @@ package:
     sha256: e0059445263a8a959066f2760beb9a5bfd49a89f64bf82716be79e456894fbf9
   category: main
   optional: false
+- name: fiona
+  version: 1.9.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    attrs: '>=19.2.0'
+    click: '>=8.0,<9.dev0'
+    click-plugins: '>=1.0'
+    cligj: '>=0.5'
+    gdal: ''
+    libcxx: '>=15'
+    libgdal: '>=3.8.2,<3.9.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: ''
+    shapely: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.5-py311hd2ff552_3.conda
+  hash:
+    md5: c2d0463951b4501e6e4a8a5062183558
+    sha256: bdae4a129ac89fc2ccca801dd557cd36665db6682c166fde4a2d9555d016b77b
+  category: main
+  optional: false
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: main
+  optional: false
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
@@ -1459,6 +2718,17 @@ package:
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   category: main
   optional: false
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: main
+  optional: false
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -1470,10 +2740,32 @@ package:
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   category: main
   optional: false
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: main
+  optional: false
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+  hash:
+    md5: 6185f640c43843e5ad6fd1c5372c3f80
+    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
+  category: main
+  optional: false
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
   hash:
@@ -1497,6 +2789,20 @@ package:
     sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
   category: main
   optional: false
+- name: fontconfig
+  version: 2.14.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  hash:
+    md5: 86cc5867dfbee4178118392bae4a3c89
+    sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  category: main
+  optional: false
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -1509,10 +2815,37 @@ package:
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   category: main
   optional: false
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: main
+  optional: false
 - name: fonts-conda-forge
   version: '1'
   manager: conda
   platform: linux-64
+  dependencies:
+    font-ttf-dejavu-sans-mono: ''
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  hash:
+    md5: f766549260d6815b0c52253f1fb1bb29
+    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  category: main
+  optional: false
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: osx-64
   dependencies:
     font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
@@ -1540,10 +2873,38 @@ package:
     sha256: bbf00a8da6c109cb139dd1e691052081e7e1e28ff2a849e7297c9e71588a6d6f
   category: main
   optional: false
+- name: fonttools
+  version: 4.49.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli: ''
+    munkres: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.49.0-py311he705e18_0.conda
+  hash:
+    md5: fc14300cb29ba11efaaa294b3efb14e0
+    sha256: 8ac8c8836616dcf366fd539951367d1e0f3a0f3e519287b3218665cb37366bfc
+  category: main
+  optional: false
 - name: fqdn
   version: 1.5.1
   manager: conda
   platform: linux-64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  category: main
+  optional: false
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: osx-64
   dependencies:
     cached-property: '>=1.3.0'
     python: '>=2.7,<4'
@@ -1567,6 +2928,19 @@ package:
     sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   category: main
   optional: false
+- name: freetype
+  version: 2.12.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libpng: '>=1.6.39,<1.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  hash:
+    md5: 25152fce119320c980e5470e64834b50
+    sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  category: main
+  optional: false
 - name: freexl
   version: 2.0.0
   manager: conda
@@ -1580,6 +2954,20 @@ package:
   hash:
     md5: 12e6988845706b2cfbc3bc35c9a61a95
     sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+  category: main
+  optional: false
+- name: freexl
+  version: 2.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    minizip: '>=4.0.1,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  hash:
+    md5: 640c34a8084e2a812bcee5b804597fc9
+    sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
   category: main
   optional: false
 - name: frozenlist
@@ -1596,10 +2984,35 @@ package:
     sha256: 56917dda8da109d51a3b25d30256365e1676f7b2fbaf793a3f003e51548bf794
   category: main
   optional: false
+- name: frozenlist
+  version: 1.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.1-py311he705e18_0.conda
+  hash:
+    md5: 6b64f053b1a2e3bfe1f93c2714844ef0
+    sha256: 6c496e4a740f191d7ab23744d39bd6d415789f9d5dcf74ed043a16a3f8968ef4
+  category: main
+  optional: false
 - name: fsspec
   version: 2023.10.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+  hash:
+    md5: 5b86cf1ceaaa9be2ec4627377e538db1
+    sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+  category: main
+  optional: false
+- name: fsspec
+  version: 2023.10.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
@@ -1628,10 +3041,45 @@ package:
     sha256: 8c54dabcc6152c22da82e69bdf7923ea58370986056aa0a0757bc24a4824be0d
   category: main
   optional: false
+- name: gdal
+  version: 3.8.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libcxx: '>=16'
+    libgdal: 3.8.4
+    libxml2: '>=2.12.5,<3.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.4-py311haaa0e4f_0.conda
+  hash:
+    md5: 0c9856c2b72926928e10fcfc0a6120f9
+    sha256: 99851b21754b61706c813ff3c2d01b4e1a5c336f86670be88a4e5224074ce619
+  category: main
+  optional: false
 - name: geopandas-base
   version: 0.14.3
   manager: conda
   platform: linux-64
+  dependencies:
+    packaging: ''
+    pandas: '>=1.4.0'
+    pyproj: '>=3.3.0'
+    python: '>=3.9'
+    shapely: '>=1.8.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
+  hash:
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
+  category: main
+  optional: false
+- name: geopandas-base
+  version: 0.14.3
+  manager: conda
+  platform: osx-64
   dependencies:
     packaging: ''
     pandas: '>=1.4.0'
@@ -1657,6 +3105,19 @@ package:
     sha256: 2593b255cb9c4639d6ea261c47aaed1380216a366546f0468e95c36c2afd1c1a
   category: main
   optional: false
+- name: geos
+  version: 3.12.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
+  hash:
+    md5: d13f05ed3985f57456b610bab66366db
+    sha256: 6feffb0d1999a22c5f94d2168b1af9c5fbdd25c9a963a6825ee32cf05e5c07f5
+  category: main
+  optional: false
 - name: geotiff
   version: 1.7.1
   manager: conda
@@ -1675,6 +3136,24 @@ package:
     sha256: f7dcc865f5522713048397702490ba917abf9d2fbfe89d6b703e0ea333a27b01
   category: main
   optional: false
+- name: geotiff
+  version: 1.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    proj: '>=9.3.1,<9.3.2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h509af15_15.conda
+  hash:
+    md5: 96cb876ae9551821ad4cd6ce860d75f1
+    sha256: e6047c9008746788d265ec6b30551387efd204a5a9a599f0f0359956e8513e76
+  category: main
+  optional: false
 - name: gettext
   version: 0.21.1
   manager: conda
@@ -1685,6 +3164,18 @@ package:
   hash:
     md5: 14947d8770185e5153fdd04d4673ed37
     sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+  category: main
+  optional: false
+- name: gettext
+  version: 0.21.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+  hash:
+    md5: 1e3aff29ce703d421c43f371ad676cc5
+    sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
   category: main
   optional: false
 - name: gflags
@@ -1700,6 +3191,18 @@ package:
     sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
   category: main
   optional: false
+- name: gflags
+  version: 2.2.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=10.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  hash:
+    md5: 3f59cc77a929537e42120faf104e0d16
+    sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  category: main
+  optional: false
 - name: giflib
   version: 5.2.1
   manager: conda
@@ -1710,6 +3213,17 @@ package:
   hash:
     md5: 96f3b11872ef6fad973eac856cd2624f
     sha256: 41ec165704ccce2faa0437f4f53c03c06261a2cc9ff7614828e51427d9261f4b
+  category: main
+  optional: false
+- name: giflib
+  version: 5.2.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+  hash:
+    md5: aca150b0186836f893ebac79019e5498
+    sha256: 47515e0874bcf67e438e1d5d093b074c1781f055067195f0d00a7790a56d446d
   category: main
   optional: false
 - name: gitdb
@@ -1725,10 +3239,37 @@ package:
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
   category: main
   optional: false
+- name: gitdb
+  version: 4.0.11
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+    smmap: '>=3.0.1,<6'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  hash:
+    md5: 623b19f616f2ca0c261441067e18ae40
+    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  category: main
+  optional: false
 - name: gitpython
   version: 3.1.42
   manager: conda
   platform: linux-64
+  dependencies:
+    gitdb: '>=4.0.1,<5'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.42-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6bc8e496351bafd761c0922c3ebd989a
+    sha256: a11e1cf4404157467d0f51906d1db80bcb8bfe4bb3d3eba703b28e981ea7e308
+  category: main
+  optional: false
+- name: gitpython
+  version: 3.1.42
+  manager: conda
+  platform: osx-64
   dependencies:
     gitdb: '>=4.0.1,<5'
     python: '>=3.7'
@@ -1753,6 +3294,19 @@ package:
     sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
   category: main
   optional: false
+- name: glog
+  version: 0.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gflags: '>=2.2.2,<2.3.0a0'
+    libcxx: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  hash:
+    md5: 69eb97ca709a136c53fdca1f2fd33ddf
+    sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  category: main
+  optional: false
 - name: gmp
   version: 6.3.0
   manager: conda
@@ -1764,6 +3318,19 @@ package:
   hash:
     md5: 0e33ef437202db431aa5a928248cf2e8
     sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h93d8f39_0.conda
+  hash:
+    md5: a4ffd4bfd88659cbecbd36b61594bf0d
+    sha256: 49443e6c41070e3967936c7f09b7686d3dd715f3351918c4edfd8072e1776013
   category: main
   optional: false
 - name: gmpy2
@@ -1783,6 +3350,22 @@ package:
     sha256: 20862200f4d07ba583ab6ae9b56d7de2462474240872100973711dfa20d562d7
   category: main
   optional: false
+- name: gmpy2
+  version: 2.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    mpc: '>=1.2.1,<2.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.2-py311hc5b4402_1.tar.bz2
+  hash:
+    md5: 658d2cc5cfce328fe85ab46259250e03
+    sha256: d1985edd5ebbc82c7805fe2c0eea0a87f2a2ea98fecd956ba534a1a02a3f74d7
+  category: main
+  optional: false
 - name: greenlet
   version: 3.0.3
   manager: conda
@@ -1798,10 +3381,38 @@ package:
     sha256: e6228b46b15ee3f54592c8a1fc1bf3846d519719ac65c238c20e21eb431971ec
   category: main
   optional: false
+- name: greenlet
+  version: 3.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/greenlet-3.0.3-py311hdd0406b_0.conda
+  hash:
+    md5: 4f538c462a4fed3aa89ea7993506c478
+    sha256: 472971e11c0a4bffdad925523ae524361567a6428e7d5e38a76fadc59eaa8efc
+  category: main
+  optional: false
 - name: h5netcdf
   version: 1.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    h5py: ''
+    packaging: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6890388078d9a3a20ef793c5ffb169ed
+    sha256: 0195b109e6b18d7efa06124d268fd5dd426f67e2feaee50a358211ba4a4b219b
+  category: main
+  optional: false
+- name: h5netcdf
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     h5py: ''
     packaging: ''
@@ -1829,6 +3440,22 @@ package:
     sha256: 77b40eae2ee8dcd664c47a62358aceec774494610bca8cba8e63a42a3fd1a2ff
   category: main
   optional: false
+- name: h5py
+  version: 3.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cached-property: ''
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.10.0-nompi_py311hf7b785c_101.conda
+  hash:
+    md5: 86e999d0a7f8d24e6c28704463c4a3ff
+    sha256: de0f18dff01fa9b167bc54677728c3b5aff027df82efa56e1893606cea7d792d
+  category: main
+  optional: false
 - name: hdf4
   version: 4.2.15
   manager: conda
@@ -1842,6 +3469,20 @@ package:
   hash:
     md5: bd77f8da987968ec3927990495dc22e4
     sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  category: main
+  optional: false
+- name: hdf4
+  version: 4.2.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  hash:
+    md5: 7ce543bf38dbfae0de9af112ee178af2
+    sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
   category: main
   optional: false
 - name: hdf5
@@ -1863,10 +3504,43 @@ package:
     sha256: b814f8f9598cc6e50127533ec256725183ba69db5fd8cf5443223627f19e3e59
   category: main
   optional: false
+- name: hdf5
+  version: 1.14.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libaec: '>=1.1.2,<2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
+  hash:
+    md5: 8e2ac4ae815a8c9743fe37d70f48f075
+    sha256: 158dd2ab901659b47e8f7ee0ec1d9e45a1fedc4871391a44a1c8b9e8ba4c9c6b
+  category: main
+  optional: false
 - name: html5lib
   version: '1.1'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+    six: '>=1.9'
+    webencodings: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: b2355343d6315c892543200231d7154a
+    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+  category: main
+  optional: false
+- name: html5lib
+  version: '1.1'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
     six: '>=1.9'
@@ -1896,6 +3570,25 @@ package:
     sha256: 9847287f52cb52ab33bb77959fc5af1a80a1a69139c1b543a24bf9b2b6de5a58
   category: main
   optional: false
+- name: huggingface_hub
+  version: 0.17.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    filelock: ''
+    fsspec: ''
+    packaging: '>=20.9'
+    python: '>=3.8.0'
+    pyyaml: '>=5.1'
+    requests: ''
+    tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.17.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: ec7be5374ac363f63c13bfc7e78144e2
+    sha256: 9847287f52cb52ab33bb77959fc5af1a80a1a69139c1b543a24bf9b2b6de5a58
+  category: main
+  optional: false
 - name: icu
   version: '73.2'
   manager: conda
@@ -1909,10 +3602,33 @@ package:
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
   category: main
   optional: false
+- name: icu
+  version: '73.2'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  hash:
+    md5: 5cc301d759ec03f28328428e28f65591
+    sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  category: main
+  optional: false
 - name: idna
   version: '3.6'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a76f09108576397c41c0b0c5bd84134
+    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+  category: main
+  optional: false
+- name: idna
+  version: '3.6'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
@@ -1964,10 +3680,66 @@ package:
     sha256: 65561329a07b27f1b14c92714194ade6db8c7c9c3dc4f850876b5e32d1bc025a
   category: main
   optional: false
+- name: imagecodecs
+  version: 2024.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    blosc: '>=1.21.5,<2.0a0'
+    brunsli: '>=0.1,<1.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    c-blosc2: '>=2.12.0,<3.0a0'
+    charls: '>=2.4.2,<2.5.0a0'
+    giflib: '>=5.2.1,<5.3.0a0'
+    jxrlib: '>=1.1,<1.2.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    lerc: '>=4.0.0,<5.0a0'
+    libaec: '>=1.1.2,<2.0a0'
+    libavif16: '>=1.0.1,<2.0a0'
+    libbrotlicommon: '>=1.1.0,<1.2.0a0'
+    libbrotlidec: '>=1.1.0,<1.2.0a0'
+    libbrotlienc: '>=1.1.0,<1.2.0a0'
+    libcxx: '>=15'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libzopfli: '>=1.0.3,<1.1.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    snappy: '>=1.1.10,<2.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zfp: '>=1.0.1,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2024.1.1-py311h5e2a27e_0.conda
+  hash:
+    md5: e62f170c21445a1bb2270227b1dffe85
+    sha256: 4f0f57f73750e1501bf9d520e8b52baf00341d838625f21516b4dbcff3585953
+  category: main
+  optional: false
 - name: imageio
   version: 2.34.0
   manager: conda
   platform: linux-64
+  dependencies:
+    numpy: ''
+    pillow: '>=8.3.2'
+    python: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.34.0-pyh4b66e23_0.conda
+  hash:
+    md5: b8853659d596f967c661f544dd89ede7
+    sha256: be0eecc8b3ee49ffe3c38dedc4d3c121e18627624926f7d1d998e8027bce4266
+  category: main
+  optional: false
+- name: imageio
+  version: 2.34.0
+  manager: conda
+  platform: osx-64
   dependencies:
     numpy: ''
     pillow: '>=8.3.2'
@@ -1990,10 +3762,35 @@ package:
     sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
   category: main
   optional: false
+- name: imagesize
+  version: 1.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 7de5386c8fea29e76b303f37dde4c352
+    sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+  category: main
+  optional: false
 - name: importlib-metadata
   version: 7.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.1-pyha770c72_0.conda
+  hash:
+    md5: 746623a787e06191d80a2133e5daff17
+    sha256: e72d05f171f4567004c9360a838e9d5df21e23dcfeb945066b53a6e5f754b861
+  category: main
+  optional: false
+- name: importlib-metadata
+  version: 7.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
@@ -2016,6 +3813,19 @@ package:
     sha256: 89492a6619776e83d30fcdc6915fcb3a657cd345abcf68fdf6655540494ab0f0
   category: main
   optional: false
+- name: importlib-resources
+  version: 6.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib_resources: '>=6.1.1,<6.1.2.0a0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d04bd1b5bed9177dd7c3cef15e2b6710
+    sha256: 89492a6619776e83d30fcdc6915fcb3a657cd345abcf68fdf6655540494ab0f0
+  category: main
+  optional: false
 - name: importlib_metadata
   version: 7.0.1
   manager: conda
@@ -2028,10 +3838,35 @@ package:
     sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
   category: main
   optional: false
+- name: importlib_metadata
+  version: 7.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: '>=7.0.1,<7.0.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.1-hd8ed1ab_0.conda
+  hash:
+    md5: 4a2f43a20fa404b998859c6a470ba316
+    sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
+  category: main
+  optional: false
 - name: importlib_resources
   version: 6.1.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d5fa25cf42f3f32a12b2d874ace8574
+    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
+  category: main
+  optional: false
+- name: importlib_resources
+  version: 6.1.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
@@ -2066,8 +3901,34 @@ package:
     sha256: 6cd66445c6a287623d02fe5fad0d67f8194ac582a7147ce092920fa20a8e3eec
   category: main
   optional: false
+- name: ipykernel
+  version: 6.29.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: ''
+    appnope: ''
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    matplotlib-inline: '>=0.1'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
+    pyzmq: '>=24'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.2-pyh3cd1d5f_0.conda
+  hash:
+    md5: 70402d8d2b523e33c9b6090f5a9c74ff
+    sha256: bd454a69fe3dc80e4a11078aab370d87ee2bd863f386d619fb2bb051b4d6f82b
+  category: main
+  optional: false
 - name: ipython
-  version: 8.22.0
+  version: 8.22.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -2082,18 +3943,55 @@ package:
     pygments: '>=2.4.0'
     python: '>=3.10'
     stack_data: ''
-    traitlets: '>=5'
+    traitlets: '>=5.13.0'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.0-pyh707e725_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.1-pyh707e725_0.conda
   hash:
-    md5: d73c395e023234276a7970d21621f92f
-    sha256: c4ca780d569ed762a0203335f381fecc4c920f6546a790d4c79cca696465cccb
+    md5: ae1a7c921e48dd420c6249fd6dab3799
+    sha256: a18d481fb2d395a7dc70ef698ea6585341baa0003a230331afd05cb75c0912b2
+  category: main
+  optional: false
+- name: ipython
+  version: 8.22.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    decorator: ''
+    exceptiongroup: ''
+    jedi: '>=0.16'
+    matplotlib-inline: ''
+    pexpect: '>4.3'
+    pickleshare: ''
+    prompt-toolkit: '>=3.0.41,<3.1.0'
+    pygments: '>=2.4.0'
+    python: '>=3.10'
+    stack_data: ''
+    traitlets: '>=5.13.0'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.1-pyh707e725_0.conda
+  hash:
+    md5: ae1a7c921e48dd420c6249fd6dab3799
+    sha256: a18d481fb2d395a7dc70ef698ea6585341baa0003a230331afd05cb75c0912b2
   category: main
   optional: false
 - name: isoduration
   version: 20.11.0
   manager: conda
   platform: linux-64
+  dependencies:
+    arrow: '>=0.15.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  category: main
+  optional: false
+- name: isoduration
+  version: 20.11.0
+  manager: conda
+  platform: osx-64
   dependencies:
     arrow: '>=0.15.0'
     python: '>=3.7'
@@ -2116,10 +4014,36 @@ package:
     sha256: 232b40de8176fa7fb66a893653f8ae03c29616e04a83dae5a47df94b74e256ca
   category: main
   optional: false
+- name: jaraco.classes
+  version: 3.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c541ae264c9f1f21d83fc30dffb908ee
+    sha256: 232b40de8176fa7fb66a893653f8ae03c29616e04a83dae5a47df94b74e256ca
+  category: main
+  optional: false
 - name: jedi
   version: 0.19.1
   manager: conda
   platform: linux-64
+  dependencies:
+    parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  category: main
+  optional: false
+- name: jedi
+  version: 0.19.1
+  manager: conda
+  platform: osx-64
   dependencies:
     parso: '>=0.8.3,<0.9.0'
     python: '>=3.6'
@@ -2154,10 +4078,36 @@ package:
     sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
   category: main
   optional: false
+- name: jinja2
+  version: 3.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    markupsafe: '>=2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: e7d8df6509ba635247ff9aea31134262
+    sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
+  category: main
+  optional: false
 - name: joblib
   version: 1.3.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
+  category: main
+  optional: false
+- name: joblib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     setuptools: ''
@@ -2179,6 +4129,17 @@ package:
     sha256: 5646496ca07dfa1486d27ed07282967007811dfc63d6394652e87f94166ecae3
   category: main
   optional: false
+- name: json-c
+  version: '0.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
+  hash:
+    md5: 266d2e4ebbf37091c8322937392bb540
+    sha256: 2a493095fe1292108ff1799a1b47ababe82d844bfa3abcf2252676c1017a1e04
+  category: main
+  optional: false
 - name: json5
   version: 0.9.17
   manager: conda
@@ -2191,10 +4152,43 @@ package:
     sha256: e01ee861d57b748874f4b4f4392b82d9341f61819a35095b4f68fbdfc93041a1
   category: main
   optional: false
+- name: json5
+  version: 0.9.17
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.17-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0e1b14ff0f0762acca0f87c26c9b75ad
+    sha256: e01ee861d57b748874f4b4f4392b82d9341f61819a35095b4f68fbdfc93041a1
+  category: main
+  optional: false
 - name: jsonargparse
   version: 4.27.5
   manager: conda
   platform: linux-64
+  dependencies:
+    argcomplete: '>=2.0.0'
+    dataclasses: '>=0.8'
+    docstring_parser: '>=0.7.3'
+    fsspec: '>=0.8.4'
+    jsonnet: '>=0.13.0'
+    jsonschema: '>=3.2.0'
+    python: '>=3.7'
+    pyyaml: '>=3.13'
+    requests: '>=2.18.4'
+    validators: '>=0.14.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonargparse-4.27.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6ba19ab281df78477e3184453cb208e5
+    sha256: add17ccec94c2ce9510d5ab7055ee69cddd3ff16bf0673c612e6fbae84ac5da2
+  category: main
+  optional: false
+- name: jsonargparse
+  version: 4.27.5
+  manager: conda
+  platform: osx-64
   dependencies:
     argcomplete: '>=2.0.0'
     dataclasses: '>=0.8'
@@ -2227,6 +4221,20 @@ package:
     sha256: 252f22555f7d7ef67a5471a6e91bfb1a272cfd7b1032ad36badd92bfcb040c36
   category: main
   optional: false
+- name: jsonnet
+  version: 0.20.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonnet-0.20.0-py311hdf8f085_1.conda
+  hash:
+    md5: ad6a632d797250cdb5e4a88d38cbff2a
+    sha256: 8337a21533de78388320ea090b355a770dd7e8556f5f5dcf746ef8698587fddd
+  category: main
+  optional: false
 - name: jsonpointer
   version: '2.4'
   manager: conda
@@ -2238,6 +4246,19 @@ package:
   hash:
     md5: 41d52d822edf991bf0e6b08c1921a8ec
     sha256: 976f7bf3c3a49c3066f36b67c12ae06b31542e53b843bb4362f31c9e449c6c46
+  category: main
+  optional: false
+- name: jsonpointer
+  version: '2.4'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py311h6eed73b_3.conda
+  hash:
+    md5: ed1c23d0e55abd27d8b9e31c58105140
+    sha256: b0ba738e1dbf3b69558557cd1e63310364e045b8c8e7f73fdce7e71928b5f22a
   category: main
   optional: false
 - name: jsonschema
@@ -2258,10 +4279,42 @@ package:
     sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
   category: main
   optional: false
+- name: jsonschema
+  version: 4.21.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8a3a3d01629da20befa340919e3dd2c4
+    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
+  category: main
+  optional: false
 - name: jsonschema-specifications
   version: 2023.12.1
   manager: conda
   platform: linux-64
+  dependencies:
+    importlib_resources: '>=1.4.0'
+    python: '>=3.8'
+    referencing: '>=0.31.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a0e4efb5f35786a05af4809a2fb1f855
+    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+  category: main
+  optional: false
+- name: jsonschema-specifications
+  version: 2023.12.1
+  manager: conda
+  platform: osx-64
   dependencies:
     importlib_resources: '>=1.4.0'
     python: '>=3.8'
@@ -2293,54 +4346,127 @@ package:
     sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
   category: main
   optional: false
+- name: jsonschema-with-format-nongpl
+  version: 4.21.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    fqdn: ''
+    idna: ''
+    isoduration: ''
+    jsonpointer: '>1.13'
+    jsonschema: '>=4.21.1,<4.21.2.0a0'
+    python: ''
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
+    webcolors: '>=1.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 26bce4b5405738c09304d4f4796b2c2a
+    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
+  category: main
+  optional: false
 - name: jupyter-book
-  version: 0.15.1
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=7.1,<9'
-    docutils: '>=0.15,<0.19'
+    importlib-metadata: '>=4.8.3'
     jinja2: ''
     jsonschema: <5
-    linkify-it-py: '>=2.0.0,<2.1.0'
-    myst-nb: '>=0.17.1,<0.18.0'
-    python: '>=3.7'
+    linkify-it-py: '>=2,<3'
+    myst-nb: '>=1,<3'
+    myst-parser: '>=1,<3'
+    python: '>=3.9'
     pyyaml: ''
-    sphinx: '>=4,<6'
-    sphinx-book-theme: '>=1.0.0,<1.1.0'
+    sphinx: '>=5,<8'
+    sphinx-book-theme: '>=1.1.0,<2'
     sphinx-comments: ''
     sphinx-copybutton: ''
-    sphinx-design: '>=0.3.0,<0.4.0'
-    sphinx-external-toc: '>=0.3.1,<0.4.0'
-    sphinx-jupyterbook-latex: '>=0.5.2,<0.6.0'
-    sphinx-multitoc-numbering: '>=0.1.3,<0.2.0'
-    sphinx-thebe: '>=0.2.0,<0.3.0'
+    sphinx-design: '>=0.5,<1'
+    sphinx-external-toc: '>=1.0.1,<2'
+    sphinx-jupyterbook-latex: '>=1,<2'
+    sphinx-multitoc-numbering: '>=0.1.3,<1'
+    sphinx-thebe: '>=0.3,<1'
     sphinx-togglebutton: ''
-    sphinxcontrib-bibtex: '>=2.2.0,<=2.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-book-0.15.1-pyhd8ed1ab_0.conda
+    sphinxcontrib-bibtex: '>=2.5.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-book-1.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f10d556d3b3dc0aeae6aee37c412ea60
-    sha256: b50732cd6ab656781f13aa43b8ce420266508235a1fb4ec7d49ca677dbe2a3d0
+    md5: 0f03c3aa37353190728ac39434a69a98
+    sha256: fcde2e48a120627116f46de331acab53f4e272ace00e9f98e0bed424805f5138
+  category: main
+  optional: false
+- name: jupyter-book
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=7.1,<9'
+    importlib-metadata: '>=4.8.3'
+    jinja2: ''
+    jsonschema: <5
+    linkify-it-py: '>=2,<3'
+    myst-nb: '>=1,<3'
+    myst-parser: '>=1,<3'
+    python: '>=3.9'
+    pyyaml: ''
+    sphinx: '>=5,<8'
+    sphinx-book-theme: '>=1.1.0,<2'
+    sphinx-comments: ''
+    sphinx-copybutton: ''
+    sphinx-design: '>=0.5,<1'
+    sphinx-external-toc: '>=1.0.1,<2'
+    sphinx-jupyterbook-latex: '>=1,<2'
+    sphinx-multitoc-numbering: '>=0.1.3,<1'
+    sphinx-thebe: '>=0.3,<1'
+    sphinx-togglebutton: ''
+    sphinxcontrib-bibtex: '>=2.5.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-book-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0f03c3aa37353190728ac39434a69a98
+    sha256: fcde2e48a120627116f46de331acab53f4e272ace00e9f98e0bed424805f5138
   category: main
   optional: false
 - name: jupyter-cache
-  version: 0.6.1
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
     attrs: ''
     click: ''
     importlib-metadata: ''
-    nbclient: '>=0.2,<0.8'
+    nbclient: '>=0.2'
     nbformat: ''
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: ''
     sqlalchemy: '>=1.3.12,<3'
     tabulate: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-0.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-1.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e360820ae68e3d28e1a5a9d2714ca5c
-    sha256: b22ba507904f33fcc7b218cc2a3ed8d39027524d0f223f3696b8344b7c5a1e1f
+    md5: b667cf7b57baa559f628d374f017fa32
+    sha256: 16dd4d3601d0532bbe755267486d62f7c77e099d0f0517e20ef635f836425d57
+  category: main
+  optional: false
+- name: jupyter-cache
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    attrs: ''
+    click: ''
+    importlib-metadata: ''
+    nbclient: '>=0.2'
+    nbformat: ''
+    python: '>=3.9'
+    pyyaml: ''
+    sqlalchemy: '>=1.3.12,<3'
+    tabulate: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b667cf7b57baa559f628d374f017fa32
+    sha256: 16dd4d3601d0532bbe755267486d62f7c77e099d0f0517e20ef635f836425d57
   category: main
   optional: false
 - name: jupyter-lsp
@@ -2357,10 +4483,42 @@ package:
     sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
   category: main
   optional: false
+- name: jupyter-lsp
+  version: 2.2.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: ed56b103cac2db68f22909e9f5cca6b6
+    sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
+  category: main
+  optional: false
 - name: jupyter_client
   version: 8.6.0
   manager: conda
   platform: linux-64
+  dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6bd3f1069cdebb44c7ae9efb900e312d
+    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
+  category: main
+  optional: false
+- name: jupyter_client
+  version: 8.6.0
+  manager: conda
+  platform: osx-64
   dependencies:
     importlib_metadata: '>=4.8.3'
     jupyter_core: '>=4.12,!=5.0.*'
@@ -2390,10 +4548,44 @@ package:
     sha256: fcfaa3875882ff564e1ea40d8a0d9b615d1f7782bf197c94983da9538e2e30fe
   category: main
   optional: false
+- name: jupyter_core
+  version: 5.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    platformdirs: '>=2.5'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.1-py311h6eed73b_0.conda
+  hash:
+    md5: dba0081b62395e6a79a63d26d75da2b3
+    sha256: f86209d1e2bc1a0e8133c3ca7e5f8296a0ca2bf25c2c16689805c487363bd304
+  category: main
+  optional: false
 - name: jupyter_events
   version: 0.9.0
   manager: conda
   platform: linux-64
+  dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
+    referencing: ''
+    rfc3339-validator: ''
+    rfc3986-validator: '>=0.1.1'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 00ba25993f0dba38cf72a7224e33289f
+    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
+  category: main
+  optional: false
+- name: jupyter_events
+  version: 0.9.0
+  manager: conda
+  platform: osx-64
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
     python: '>=3.8'
@@ -2439,10 +4631,53 @@ package:
     sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
   category: main
   optional: false
+- name: jupyter_server
+  version: 2.12.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    anyio: '>=3.1.0'
+    argon2-cffi: ''
+    jinja2: ''
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.9.0'
+    jupyter_server_terminals: ''
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: ''
+    packaging: ''
+    prometheus_client: ''
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.12.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 755177a956fa6dd90d5cfcbbb5084de2
+    sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
+  category: main
+  optional: false
 - name: jupyter_server_terminals
   version: 0.5.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    terminado: '>=0.8.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a0152d13c9deb13639fc84df884d50b6
+    sha256: a625150744fdffb646fb4451edc68b3eff56eeace4e86b83dc4a860479c9857c
+  category: main
+  optional: false
+- name: jupyter_server_terminals
+  version: 0.5.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
     terminado: '>=0.8.3'
@@ -2478,10 +4713,49 @@ package:
     sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
   category: main
   optional: false
+- name: jupyterlab
+  version: 4.0.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    async-lru: '>=1.0.0'
+    importlib_metadata: '>=4.8.3'
+    importlib_resources: '>=1.4'
+    ipykernel: ''
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    tomli: ''
+    tornado: '>=6.2.0'
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.12-pyhd8ed1ab_0.conda
+  hash:
+    md5: be2dcb121242a2f045ef8e8240e2b29d
+    sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
+  category: main
+  optional: false
 - name: jupyterlab_pygments
   version: 0.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    pygments: '>=2.4.1,<3'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: afcd1b53bcac8844540358e33f33d28f
+    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  category: main
+  optional: false
+- name: jupyterlab_pygments
+  version: 0.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     pygments: '>=2.4.1,<3'
     python: '>=3.7'
@@ -2511,6 +4785,26 @@ package:
     sha256: 30269e4ab0e67935b15b012e5e97f5c5c72111d0f02e03b3c644e556fe1a5275
   category: main
   optional: false
+- name: jupyterlab_server
+  version: 2.25.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 78f28bcd22aadca6ec8eaff4319e6610
+    sha256: 30269e4ab0e67935b15b012e5e97f5c5c72111d0f02e03b3c644e556fe1a5275
+  category: main
+  optional: false
 - name: jxrlib
   version: '1.1'
   manager: conda
@@ -2521,6 +4815,17 @@ package:
   hash:
     md5: 5aeabe88534ea4169d4c49998f293d6c
     sha256: 2057ca87b313bde5b74b93b0e696f8faab69acd4cb0edebb78469f3f388040c0
+  category: main
+  optional: false
+- name: jxrlib
+  version: '1.1'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/jxrlib-1.1-h10d778d_3.conda
+  hash:
+    md5: cfaf81d843a80812fe16a68bdae60562
+    sha256: a548a4be14a4c76d6d992a5c1feffcbb08062f5c57abc6e4278d40c2c9a7185b
   category: main
   optional: false
 - name: kealib
@@ -2535,6 +4840,19 @@ package:
   hash:
     md5: f7e7077802927590efc8bf7328208f12
     sha256: ee0934ff426d3cab015055808bed33eb9d20f635ec14bc421c596f4b70927102
+  category: main
+  optional: false
+- name: kealib
+  version: 1.5.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-h5f07ac3_0.conda
+  hash:
+    md5: 7a0924f6214e4c17b6062b21d1240253
+    sha256: 54a847faf2d2aea83c149d98634646edb8e7f346faefc6af1aa52106200b43aa
   category: main
   optional: false
 - name: keyring
@@ -2552,6 +4870,21 @@ package:
   hash:
     md5: 09e27eb40c88f732a4e0ea5b70f63ae0
     sha256: 29909aa6935d34f46b9121bfb504e8305af525a27639bbf5d2692fce2935e9bc
+  category: main
+  optional: false
+- name: keyring
+  version: 24.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib_metadata: '>=4.11.4'
+    jaraco.classes: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/keyring-24.3.0-py311h6eed73b_0.conda
+  hash:
+    md5: 2477bfca2a6eae7d1b72530225febae6
+    sha256: 1cafeae8549f6f04da024dd2863f027b587018c7a1a570399e366053bc2cf16c
   category: main
   optional: false
 - name: keyutils
@@ -2581,6 +4914,20 @@ package:
     sha256: 723b0894d2d2b05a38f9c5a285d5a0a5baa27235ceab6531dbf262ba7c6955c1
   category: main
   optional: false
+- name: kiwisolver
+  version: 1.4.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py311h5fe6e05_1.conda
+  hash:
+    md5: 24305b23f7995de72bbd53b7c01242a2
+    sha256: 586a4d0a17e6cfd9f8fdee56106d263ee40ca156832774d6e899f82ad68ac8d0
+  category: main
+  optional: false
 - name: krb5
   version: 1.21.2
   manager: conda
@@ -2597,10 +4944,37 @@ package:
     sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
   category: main
   optional: false
+- name: krb5
+  version: 1.21.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libedit: '>=3.1.20191231,<4.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  hash:
+    md5: 80505a68783f01dc8d7308c075261b2f
+    sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  category: main
+  optional: false
 - name: latexcodec
   version: 2.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/latexcodec-2.0.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 8d67904973263afd2985ba56aa2d6bb4
+    sha256: 5210d31c8f2402dd1ad1b3edcf7a53292b9da5de20cd14d9c243dbf9278b1c4f
+  category: main
+  optional: false
+- name: latexcodec
+  version: 2.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
     six: ''
@@ -2622,6 +4996,18 @@ package:
     sha256: fa32bafbf7f9238a9cb8f0aa1fb17d2fdcefa607c217b86c38c3b670c58d1ac6
   category: main
   optional: false
+- name: lazy_loader
+  version: '0.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 69ea1d0fa7ab33b48c88394ad1dead65
+    sha256: fa32bafbf7f9238a9cb8f0aa1fb17d2fdcefa607c217b86c38c3b670c58d1ac6
+  category: main
+  optional: false
 - name: lcms2
   version: '2.16'
   manager: conda
@@ -2634,6 +5020,19 @@ package:
   hash:
     md5: 51bb7010fc86f70eee639b4bb7a894f5
     sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  category: main
+  optional: false
+- name: lcms2
+  version: '2.16'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  hash:
+    md5: 1442db8f03517834843666c422238c9b
+    sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
   category: main
   optional: false
 - name: ld_impl_linux-64
@@ -2660,6 +5059,18 @@ package:
     sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   category: main
   optional: false
+- name: lerc
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=13.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  hash:
+    md5: f9d6a4c82889d5ecedec1d90eb673c55
+    sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  category: main
+  optional: false
 - name: libabseil
   version: '20230802.1'
   manager: conda
@@ -2673,6 +5084,18 @@ package:
     sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
   category: main
   optional: false
+- name: libabseil
+  version: '20230802.1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+  hash:
+    md5: 6554f5fb47c025273268bcdb7bf3cd48
+    sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+  category: main
+  optional: false
 - name: libaec
   version: 1.1.2
   manager: conda
@@ -2684,6 +5107,18 @@ package:
   hash:
     md5: 127b0be54c1c90760d7fe02ea7a56426
     sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+  category: main
+  optional: false
+- name: libaec
+  version: 1.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+  hash:
+    md5: faa179050abc6af1385e0fe9dd074f91
+    sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
   category: main
   optional: false
 - name: libarchive
@@ -2704,6 +5139,26 @@ package:
   hash:
     md5: 3bf887827d1968275978361a6e405e4f
     sha256: 340ed0bb02fe26a2b2e29cedf6559e2999b820f434e745c108e788d629ae4b17
+  category: main
+  optional: false
+- name: libarchive
+  version: 3.7.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    lzo: '>=2.10,<3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-hd35d340_1.conda
+  hash:
+    md5: 8c7b79b20a67287a87b39df8a8c8dcc4
+    sha256: f458515a49c56e117e05fe607493b7683a7bf06d2a625b59e378dbbf7f308895
   category: main
   optional: false
 - name: libarrow
@@ -2735,6 +5190,35 @@ package:
     sha256: ec8ab78c117da8b88f73386c409ecbc8c1f1673bcbb3bde4f47af6ab413a7c8a
   category: main
   optional: false
+- name: libarrow
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-crt-cpp: '>=0.26.0,<0.26.1.0a0'
+    aws-sdk-cpp: '>=1.11.210,<1.11.211.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    glog: '>=0.6.0,<0.7.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libbrotlidec: '>=1.1.0,<1.2.0a0'
+    libbrotlienc: '>=1.1.0,<1.2.0a0'
+    libcxx: '>=14'
+    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libutf8proc: '>=2.8.0,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    orc: '>=1.9.2,<1.9.3.0a0'
+    re2: ''
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.0-h1aaacd4_0_cpu.conda
+  hash:
+    md5: b2e8a2a9cce613511f35a114fd261252
+    sha256: 2b3c0ab8bf1c53456cfe9d4190c0a4cf15c0e13f42a3036f0790a8d32b80fc1d
+  category: main
+  optional: false
 - name: libarrow-acero
   version: 15.0.0
   manager: conda
@@ -2747,6 +5231,19 @@ package:
   hash:
     md5: 3472c8807bff382e938ad85a261738f9
     sha256: 4f305e5fc7350752ac5248fbcd37ba5a0a88a628aadf341c3bcbc9949025a713
+  category: main
+  optional: false
+- name: libarrow-acero
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 15.0.0
+    libcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.0-h000cb23_0_cpu.conda
+  hash:
+    md5: 2e846a23df996a8bdad4062625917a71
+    sha256: dc98876d07ed4ed78421d251796fa87bf9987d6b3c3ea1a008690c063c7b2435
   category: main
   optional: false
 - name: libarrow-dataset
@@ -2763,6 +5260,21 @@ package:
   hash:
     md5: 77a3299d7f6afb2e274c12d7395346b0
     sha256: f648faaddf25a697376b407cad4aaf593c14b7d264dc1013c7d75378554f2cc7
+  category: main
+  optional: false
+- name: libarrow-dataset
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 15.0.0
+    libarrow-acero: 15.0.0
+    libcxx: '>=14'
+    libparquet: 15.0.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.0-h000cb23_0_cpu.conda
+  hash:
+    md5: 4bd6394431a7bfedf5ef9848e832b69b
+    sha256: b24739ed304b4e46382234fe1020c0f338b091292a98f707e320f016ec9cd63d
   category: main
   optional: false
 - name: libarrow-flight
@@ -2783,6 +5295,23 @@ package:
     sha256: f2d5916d993a90c05cbb6830809cb5470af8570bbae0da8784e385577d91a3ab
   category: main
   optional: false
+- name: libarrow-flight
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libarrow: 15.0.0
+    libcxx: '>=14'
+    libgrpc: '>=1.59.3,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.0-ha1803ca_0_cpu.conda
+  hash:
+    md5: 296b77ef6cf42ff01ad0b45bc223eaf6
+    sha256: 105551d2c15ce1e61176690644a9f5b22adb87d6e87910f93d7f6299d062bba1
+  category: main
+  optional: false
 - name: libarrow-flight-sql
   version: 15.0.0
   manager: conda
@@ -2797,6 +5326,22 @@ package:
   hash:
     md5: 9d710114caa170858339ed1a99facbe6
     sha256: 8485b0af1503429c34c892fd82c9167934c28c95af57b7edb167e0bf3d0ccd00
+  category: main
+  optional: false
+- name: libarrow-flight-sql
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libarrow: 15.0.0
+    libarrow-flight: 15.0.0
+    libcxx: '>=14'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.0-h8ec153b_0_cpu.conda
+  hash:
+    md5: 380b2bff75201a8b1b9a27b4e645d7b7
+    sha256: a49d6c35bc042a046f8213074905518fa2eb559074bde5dcfbade076c40ecf40
   category: main
   optional: false
 - name: libarrow-gandiva
@@ -2818,6 +5363,24 @@ package:
     sha256: ff0c88547635c0947beb5edc9f8fcbdf0f79d9b3b6aeb6614c896e79bc3179f8
   category: main
   optional: false
+- name: libarrow-gandiva
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 15.0.0
+    libcxx: '>=14'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libutf8proc: '>=2.8.0,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.0-h01dce7f_0_cpu.conda
+  hash:
+    md5: 93ec7f2b11cbed836f39c70901a308aa
+    sha256: 429ff9442149adc528f4d81fa2eeb370990d7601947cf11d829ae084150afd11
+  category: main
+  optional: false
 - name: libarrow-substrait
   version: 15.0.0
   manager: conda
@@ -2833,6 +5396,23 @@ package:
   hash:
     md5: 636da1ef050231a6ace3fbd5b3a4e03e
     sha256: f07e62d97781bbb2584944a4b4426fd4eae1ec3967aa99ade2b874c31af7e360
+  category: main
+  optional: false
+- name: libarrow-substrait
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libarrow: 15.0.0
+    libarrow-acero: 15.0.0
+    libarrow-dataset: 15.0.0
+    libcxx: '>=14'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.0-h8ec153b_0_cpu.conda
+  hash:
+    md5: 36aa0a4cde810dedeaf96202c389aec8
+    sha256: f1e224d941b702b3b48107127ee914cb77fb524b1f0bbaefa33dd2c77ff4bf0b
   category: main
   optional: false
 - name: libavif16
@@ -2851,6 +5431,21 @@ package:
     sha256: f57edcb0ac9f1f9665369c833620497c6c2347f339f767b9d922d74c35bc3193
   category: main
   optional: false
+- name: libavif16
+  version: 1.0.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aom: '>=3.8.1,<3.9.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    rav1e: '>=0.6.6,<1.0a0'
+    svt-av1: '>=1.8.0,<1.8.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.0.4-hddeac66_0.conda
+  hash:
+    md5: 175da30f6c54603b694114c0d41cb34f
+    sha256: 1931f1c61453a10b17c9f74e4752f68095fd0a5d2996b92d33b09a1163e03ad0
+  category: main
+  optional: false
 - name: libblas
   version: 3.9.0
   manager: conda
@@ -2861,6 +5456,18 @@ package:
   hash:
     md5: 0ac9f44fc096772b0aa092119b00c3ca
     sha256: ebd5c91f029f779fb88a1fcbd1e499559a9c258e3674ff58a2fbb4e375ae56d9
+  category: main
+  optional: false
+- name: libblas
+  version: 3.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libopenblas: '>=0.3.26,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: 23286066c595986aa0df6452a8416c08
+    sha256: 5381eab20f4793996cf22e58461ea8a3a4dff1442bb45663b5920f2d26288688
   category: main
   optional: false
 - name: libboost-headers
@@ -2874,6 +5481,17 @@ package:
     sha256: f5ac6b12768e5c735d2c8e4e1e05093b105d649a68f02f6a5349f5cb61719b9c
   category: main
   optional: false
+- name: libboost-headers
+  version: 1.84.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_1.conda
+  hash:
+    md5: 530c932ca58015980579dbd0dbc7001e
+    sha256: cbe9834e3ea802ae6ab98ecde36d9840afd1bca768aabcb766a237124abcdfa2
+  category: main
+  optional: false
 - name: libbrotlicommon
   version: 1.1.0
   manager: conda
@@ -2884,6 +5502,17 @@ package:
   hash:
     md5: aec6c91c7371c26392a06708a73c70e5
     sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9e6c31441c9aa24e41ace40d6151aab6
+    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
   category: main
   optional: false
 - name: libbrotlidec
@@ -2899,6 +5528,18 @@ package:
     sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
   category: main
   optional: false
+- name: libbrotlidec
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9ee0bab91b2ca579e10353738be36063
+    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  category: main
+  optional: false
 - name: libbrotlienc
   version: 1.1.0
   manager: conda
@@ -2910,6 +5551,18 @@ package:
   hash:
     md5: 5fc11c6020d421960607d821310fcd4d
     sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
   category: main
   optional: false
 - name: libcblas
@@ -2924,6 +5577,18 @@ package:
     sha256: 467bbfbfe1a1aeb8b1f9f6485eedd8ed1b6318941bf3702da72336ccf4dc25a6
   category: main
   optional: false
+- name: libcblas
+  version: 3.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: 7a1b54774bad723e8ba01ca48eb301b5
+    sha256: e2b1455612d4cfb3ac3170f0c538516ebd0b113780ac6603338245354e1b2f02
+  category: main
+  optional: false
 - name: libcrc32c
   version: 1.1.2
   manager: conda
@@ -2935,6 +5600,18 @@ package:
   hash:
     md5: c965a5aa0d5c1c37ffc62dff36e28400
     sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  category: main
+  optional: false
+- name: libcrc32c
+  version: 1.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  hash:
+    md5: 23d6d5a69918a438355d7cbc4c3d54c9
+    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
   category: main
   optional: false
 - name: libcublas
@@ -3001,6 +5678,23 @@ package:
     sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
   category: main
   optional: false
+- name: libcurl
+  version: 8.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    libnghttp2: '>=1.58.0,<2.0a0'
+    libssh2: '>=1.11.0,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+  hash:
+    md5: 86d749e27fe00fa6b7d790a6feaa22a2
+    sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
+  category: main
+  optional: false
 - name: libcusolver
   version: 11.5.4.101
   manager: conda
@@ -3035,6 +5729,17 @@ package:
     sha256: 3539837b435e294f0d7786972447fb8be756471e4967501d278dad47ed4ae8d5
   category: main
   optional: false
+- name: libcxx
+  version: 16.0.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  hash:
+    md5: 7d6972792161077908b62971802f289a
+    sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  category: main
+  optional: false
 - name: libdeflate
   version: '1.19'
   manager: conda
@@ -3045,6 +5750,17 @@ package:
   hash:
     md5: 1635570038840ee3f9c71d22aa5b8b6d
     sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  category: main
+  optional: false
+- name: libdeflate
+  version: '1.19'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  hash:
+    md5: 6a45f543c2beb40023df5ee7e3cedfbd
+    sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
   category: main
   optional: false
 - name: libedit
@@ -3060,6 +5776,18 @@ package:
     sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   category: main
   optional: false
+- name: libedit
+  version: 3.1.20191231
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.2,<7.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  hash:
+    md5: 6016a8a1d0e63cac3de2c352cd40208b
+    sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  category: main
+  optional: false
 - name: libev
   version: '4.33'
   manager: conda
@@ -3070,6 +5798,17 @@ package:
   hash:
     md5: 172bf1cd1ff8629f2b1179945ed45055
     sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  hash:
+    md5: 899db79329439820b7e8f8de41bca902
+    sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
   category: main
   optional: false
 - name: libevent
@@ -3085,6 +5824,18 @@ package:
     sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
   category: main
   optional: false
+- name: libevent
+  version: 2.1.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  hash:
+    md5: e38e467e577bd193a7d5de7c2c540b04
+    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  category: main
+  optional: false
 - name: libexpat
   version: 2.5.0
   manager: conda
@@ -3097,6 +5848,17 @@ package:
     sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
   category: main
   optional: false
+- name: libexpat
+  version: 2.5.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  hash:
+    md5: 6c81cb022780ee33435cca0127dd43c9
+    sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  category: main
+  optional: false
 - name: libffi
   version: 3.4.2
   manager: conda
@@ -3107,6 +5869,17 @@ package:
   hash:
     md5: d645c6d2ac96843a2bfaccd2d62b3ac3
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  category: main
+  optional: false
+- name: libffi
+  version: 3.4.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  hash:
+    md5: ccb34fb14960ad8b125962d3d79b31a9
+    sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
   category: main
   optional: false
 - name: libgcc-ng
@@ -3176,6 +5949,69 @@ package:
     sha256: af88738b2eda7d388daad5bd7dd8fe66efbaba300921ecb6fb03d9c5823a950d
   category: main
   optional: false
+- name: libgdal
+  version: 3.8.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    blosc: '>=1.21.5,<2.0a0'
+    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    freexl: '>=2.0.0,<3.0a0'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    geotiff: '>=1.7.1,<1.8.0a0'
+    giflib: '>=5.2.1,<5.3.0a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    json-c: '>=0.17,<0.18.0a0'
+    kealib: '>=1.5.3,<1.6.0a0'
+    lerc: '>=4.0.0,<5.0a0'
+    libaec: '>=1.1.2,<2.0a0'
+    libarchive: '>=3.7.2,<3.8.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libnetcdf: '>=4.9.2,<4.9.3.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
+    libspatialite: '>=5.1.0,<5.2.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    pcre2: '>=10.42,<10.43.0a0'
+    poppler: '>=24.2.0,<24.3.0a0'
+    postgresql: ''
+    proj: '>=9.3.1,<9.3.2.0a0'
+    tiledb: '>=2.20.0,<2.21.0a0'
+    xerces-c: '>=3.2.5,<3.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h46636ed_0.conda
+  hash:
+    md5: 5cf7d0f51e6e9dd8d175d8660b843024
+    sha256: 12a0151e5e0d05590bcf5c6abf2fe36977df8b1198564198c167ed05492d5b1b
+  category: main
+  optional: false
+- name: libgfortran
+  version: 5.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran5: 13.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  hash:
+    md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+    sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  category: main
+  optional: false
 - name: libgfortran-ng
   version: 13.2.0
   manager: conda
@@ -3200,6 +6036,18 @@ package:
     sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
   category: main
   optional: false
+- name: libgfortran5
+  version: 13.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=8.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  hash:
+    md5: e4fb4d23ec2870ff3c40d10afe305aec
+    sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  category: main
+  optional: false
 - name: libglib
   version: 2.78.4
   manager: conda
@@ -3216,6 +6064,23 @@ package:
   hash:
     md5: d86baf8740d1a906b9716f2a0bac2f2d
     sha256: 3a03a5254d2fd29c1e0ffda7250e22991dfbf2c854301fd56c408d97a647cfbd
+  category: main
+  optional: false
+- name: libglib
+  version: 2.78.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libcxx: '>=16'
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pcre2: '>=10.42,<10.43.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.4-hab64008_0.conda
+  hash:
+    md5: ff7e302784375cfc3157b8120a18124d
+    sha256: 122060ba63fd27e53672dbac7dc0b4f55a6432993446f4ed3c30a69a9457c615
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -3235,6 +6100,25 @@ package:
   hash:
     md5: b5eb63d2683102be45d17c55021282f6
     sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
+  category: main
+  optional: false
+- name: libgoogle-cloud
+  version: 2.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libgrpc: '>=1.59.2,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+  hash:
+    md5: 976555c39f83093265491c9c081a801c
+    sha256: 1bf47f43796369ec85a27221ab9a84ecc848f93a88049d046cd8521c25b129f6
   category: main
   optional: false
 - name: libgrpc
@@ -3257,6 +6141,26 @@ package:
     sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
   category: main
   optional: false
+- name: libgrpc
+  version: 1.59.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    c-ares: '>=1.21.0,<2.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+  hash:
+    md5: a557d871e80f2dd22efd78e00f9a1597
+    sha256: 1b7330bb2aa16ca0dd319e97a829d5494fb2459a841b54f7631932b144e38624
+  category: main
+  optional: false
 - name: libhwloc
   version: 2.9.3
   manager: conda
@@ -3271,6 +6175,20 @@ package:
     sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
   category: main
   optional: false
+- name: libhwloc
+  version: 2.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libxml2: '>=2.11.5,<3.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+  hash:
+    md5: 22fcbfd2a4cdf941b074a00b773b43dd
+    sha256: a9fc54b481d0477cdf5700d702d44fc04fe00ffe63fc253aa0c6d2944abe8f3f
+  category: main
+  optional: false
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -3283,6 +6201,17 @@ package:
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
   category: main
   optional: false
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  hash:
+    md5: 6c3628d047e151efba7cf08c5e54d1ca
+    sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  category: main
+  optional: false
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -3293,6 +6222,17 @@ package:
   hash:
     md5: ea25936bb4080d843790b586850f82b8
     sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  category: main
+  optional: false
+- name: libjpeg-turbo
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  hash:
+    md5: 72507f8e3961bc968af17435060b6dd6
+    sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
   category: main
   optional: false
 - name: libkml
@@ -3312,6 +6252,22 @@ package:
     sha256: f67fc0be886c7eac14dbce858bfcffbc90a55b598e897e513f0979dd2caad750
   category: main
   optional: false
+- name: libkml
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libboost-headers: ''
+    libcxx: '>=15.0.7'
+    libexpat: '>=2.5.0,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    uriparser: '>=0.9.7,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
+  hash:
+    md5: 535b1bb4896b113c14dfa64141370a12
+    sha256: f546750a59b85a4b721f69e34e797ceddb93c438ee384db285e3344490d6a9b5
+  category: main
+  optional: false
 - name: liblapack
   version: 3.9.0
   manager: conda
@@ -3322,6 +6278,18 @@ package:
   hash:
     md5: 1a42f305615c3867684e049e85927531
     sha256: 64b5c35dce00dd6f9f53178b2fe87116282e00967970bd6551a5a42923806ded
+  category: main
+  optional: false
+- name: liblapack
+  version: 3.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
+  hash:
+    md5: cf0e4d82cfca6cd9d6c9ed3df45907c9
+    sha256: 5d0ef4743e8684ad436e31bd3c378d48642815a20c260d358668ba29cd80987a
   category: main
   optional: false
 - name: libllvm15
@@ -3338,6 +6306,21 @@ package:
   hash:
     md5: 8a35df3cbc0c8b12cc8af9473ae75eef
     sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
+  category: main
+  optional: false
+- name: libllvm15
+  version: 15.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    libxml2: '>=2.12.1,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
+  hash:
+    md5: bdc80cf2aa69d6eb8dd101dfd804db07
+    sha256: a0598cc166e92c6c63e58a7eaa184fa0b8b467693b965dbe19f1c9ff37e134c3
   category: main
   optional: false
 - name: libmagma
@@ -3406,6 +6389,31 @@ package:
     sha256: 0b4d984c7be21531e9254ce742e04101f7f7e77c0bbb7074855c0806c28323b0
   category: main
   optional: false
+- name: libnetcdf
+  version: 4.9.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    blosc: '>=1.21.5,<2.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libaec: '>=1.1.2,<2.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzip: '>=1.10.1,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    zlib: ''
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7760872_113.conda
+  hash:
+    md5: bce76ace6497221c2a2a02840aaceac5
+    sha256: 3d6a950d82a8dfb9fa51c263e543cfa9c113703add20646ec85401e7b557da49
+  category: main
+  optional: false
 - name: libnghttp2
   version: 1.58.0
   manager: conda
@@ -3421,6 +6429,23 @@ package:
   hash:
     md5: 700ac6ea6d53d5510591c4344d5c989a
     sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.58.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    c-ares: '>=1.23.0,<2.0a0'
+    libcxx: '>=16.0.6'
+    libev: '>=4.33,<5.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  hash:
+    md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+    sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
   category: main
   optional: false
 - name: libnl
@@ -3488,6 +6513,20 @@ package:
     sha256: b626954b5a1113dafec8df89fa8bf18ce9b4701464d9f084ddd7fc9fac404bbd
   category: main
   optional: false
+- name: libopenblas
+  version: 0.3.26
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran: 5.*
+    libgfortran5: '>=12.3.0'
+    llvm-openmp: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
+  hash:
+    md5: 9df60162aea811087267b515f359536c
+    sha256: 4a5994cc608708eca19b90b642a144bb073e4a1cd27b824281dfcae67917204e
+  category: main
+  optional: false
 - name: libparquet
   version: 15.0.0
   manager: conda
@@ -3504,6 +6543,21 @@ package:
     sha256: 505672cb7ec1e42a7e60fcee9f6cad38b35227186b2dbcf3d5f4686a4339c13a
   category: main
   optional: false
+- name: libparquet
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 15.0.0
+    libcxx: '>=14'
+    libthrift: '>=0.19.0,<0.19.1.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.0-h381d950_0_cpu.conda
+  hash:
+    md5: 8af9454451433ecef89a6baadd8575e7
+    sha256: fab9fa004d0dab465969f5f02c4091d6ec5f6f9f7023529e1c0ce8ac01f366b8
+  category: main
+  optional: false
 - name: libpng
   version: 1.6.42
   manager: conda
@@ -3515,6 +6569,18 @@ package:
   hash:
     md5: d67729828dc6ff7ba44a61062ad79880
     sha256: 1a0c3a4b7fd1e101cb37dd6d2f8b5ec93409c8cae422f04470fe39a01ef59024
+  category: main
+  optional: false
+- name: libpng
+  version: 1.6.42
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
+  hash:
+    md5: 7654da21e9d7ca6a8c87fbc77448588e
+    sha256: 57c816e3b8cd0aaca7b85e79c0cc2211789ce0729a581d006faf8daeebf51f8d
   category: main
   optional: false
 - name: libpq
@@ -3529,6 +6595,19 @@ package:
   hash:
     md5: fe0e297faf462ee579c95071a5211665
     sha256: 352748b0499a22e2a8e103f071b8d9357e1fb710c0aec0f79895d3ba03dccb03
+  category: main
+  optional: false
+- name: libpq
+  version: '16.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
+  hash:
+    md5: 8b81f4feaa3744271fcf2822ad1489f1
+    sha256: 537b3816ac66f12c56fc62a67d896703b68f7588a5d83ab98009731de82eb742
   category: main
   optional: false
 - name: libprotobuf
@@ -3546,6 +6625,21 @@ package:
     sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
   category: main
   optional: false
+- name: libprotobuf
+  version: 4.24.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=15'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-hc4f2305_0.conda
+  hash:
+    md5: b0f4b64fca855d81e9cde1ceecbcb333
+    sha256: 6516b3a430ae3678190a1ece9a8cb38a3ddd9c3acedc3955b76c1e668eeb2eb1
+  category: main
+  optional: false
 - name: libre2-11
   version: 2023.06.02
   manager: conda
@@ -3558,6 +6652,20 @@ package:
   hash:
     md5: c0e7eacd9694db3ef5ef2979a7deea70
     sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
+  category: main
+  optional: false
+- name: libre2-11
+  version: 2023.06.02
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+  hash:
+    md5: d7c00395eaf2446eec6ce0f34cfd5b78
+    sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
   category: main
   optional: false
 - name: librttopo
@@ -3574,6 +6682,20 @@ package:
     sha256: 03e248787162a1804683c614c0681c2488fa6d9f353cb32e2f8c1158157165ea
   category: main
   optional: false
+- name: librttopo
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
+  hash:
+    md5: e65bedc9d9779a161cf26b6d12305246
+    sha256: 10c46efefda5cc77143832a186f517e401098907cf9c3ec7406a5c242bb34e33
+  category: main
+  optional: false
 - name: libsodium
   version: 1.0.18
   manager: conda
@@ -3584,6 +6706,17 @@ package:
   hash:
     md5: c3788462a6fbddafdb413a9f9053e58d
     sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  category: main
+  optional: false
+- name: libsodium
+  version: 1.0.18
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  hash:
+    md5: 24632c09ed931af617fe6d5292919cab
+    sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
   category: main
   optional: false
 - name: libspatialite
@@ -3608,6 +6741,29 @@ package:
     sha256: 2d07badb81296f42dd0c59b02dbf7d64ca2c78c086226327c1e11e11f71effbd
   category: main
   optional: false
+- name: libspatialite
+  version: 5.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    freexl: '>=2.0.0,<3.0a0'
+    geos: '>=3.12.1,<3.12.2.0a0'
+    libcxx: '>=16.0.6'
+    libiconv: '>=1.17,<2.0a0'
+    librttopo: '>=1.1.0,<1.2.0a0'
+    libsqlite: '>=3.44.2,<4.0a0'
+    libxml2: '>=2.12.2,<3.0.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    proj: '>=9.3.1,<9.3.2.0a0'
+    sqlite: ''
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hebe6af1_4.conda
+  hash:
+    md5: 9e8f3012e1b4460819395357cc7c4371
+    sha256: 48ff63495ed9ed86db1fb62ea51e1053747e76481200fb33aa164f7bdb1bec93
+  category: main
+  optional: false
 - name: libsqlite
   version: 3.45.1
   manager: conda
@@ -3619,6 +6775,18 @@ package:
   hash:
     md5: fc4ccadfbf6d4784de88c41704792562
     sha256: 1b379d1c652b25d0540251d422ef767472e768fd36b77261045e97f9ba6d3faa
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.45.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
+  hash:
+    md5: e451d14a5412cdc68be50493df251f55
+    sha256: d65ce7093ecf5884b241a5ca8d26f80d21eaebf14ca67923b50c249f47a84cf9
   category: main
   optional: false
 - name: libssh2
@@ -3633,6 +6801,19 @@ package:
   hash:
     md5: 1f5a58e686b13bcfde88b93f547d23fe
     sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  category: main
+  optional: false
+- name: libssh2
+  version: 1.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  hash:
+    md5: ca3a72efba692c59a90d4b9fc0dfe774
+    sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
   category: main
   optional: false
 - name: libstdcxx-ng
@@ -3662,6 +6843,21 @@ package:
     sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
   category: main
   optional: false
+- name: libthrift
+  version: 0.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libevent: '>=2.1.12,<2.1.13.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.3,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  hash:
+    md5: b152655bfad7c2374ff03be0596052b6
+    sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  category: main
+  optional: false
 - name: libtiff
   version: 4.6.0
   manager: conda
@@ -3680,6 +6876,25 @@ package:
   hash:
     md5: 55ed21669b2015f77c180feb1dd41930
     sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  category: main
+  optional: false
+- name: libtiff
+  version: 4.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    lerc: '>=4.0.0,<5.0a0'
+    libcxx: '>=15.0.7'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  hash:
+    md5: 2ca10a325063e000ad6d2a5900061e0d
+    sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
   category: main
   optional: false
 - name: libtorch
@@ -3728,6 +6943,17 @@ package:
     sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
   category: main
   optional: false
+- name: libutf8proc
+  version: 2.8.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  hash:
+    md5: db98dc3e58cbc11583180609c429c17d
+    sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  category: main
+  optional: false
 - name: libuuid
   version: 2.38.1
   manager: conda
@@ -3752,6 +6978,17 @@ package:
     sha256: 53bd8f6bebc85555c5dd648072693e37fcdf777f993e9a108c4a7badf2e8810c
   category: main
   optional: false
+- name: libuv
+  version: 1.47.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.47.0-h67532ce_0.conda
+  hash:
+    md5: c2c8307836ecebc2799400a4eca27b37
+    sha256: a452b8fbb906e72d6c633ed133413f6a604471597f4c80dc73b4e81d2ef56b32
+  category: main
+  optional: false
 - name: libwebp-base
   version: 1.3.2
   manager: conda
@@ -3762,6 +6999,17 @@ package:
   hash:
     md5: 30de3fd9b3b602f7473f30e684eeea8c
     sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  category: main
+  optional: false
+- name: libwebp-base
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  hash:
+    md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+    sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
   category: main
   optional: false
 - name: libxcb
@@ -3777,6 +7025,20 @@ package:
   hash:
     md5: 33277193f5b92bad9fdd230eb700929c
     sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  category: main
+  optional: false
+- name: libxcb
+  version: '1.15'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pthread-stubs: ''
+    xorg-libxau: ''
+    xorg-libxdmcp: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  hash:
+    md5: 5513f57e0238c87c12dffedbcc9c1a4a
+    sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
   category: main
   optional: false
 - name: libxcrypt
@@ -3807,6 +7069,21 @@ package:
     sha256: db9bf97e9e367985204331b58a059ebd5a4e0cb9e1c8754e9ecb23046b7b7bc1
   category: main
   optional: false
+- name: libxml2
+  version: 2.12.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
+  hash:
+    md5: abe27e7ab68b95e8d0e41cd5018ec8ae
+    sha256: a84f355dcf9039ae54e21bf8833c16200f848fd333a5e68c143e142cc55dc07d
+  category: main
+  optional: false
 - name: libzip
   version: 1.10.1
   manager: conda
@@ -3822,6 +7099,20 @@ package:
     sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
   category: main
   optional: false
+- name: libzip
+  version: 1.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+  hash:
+    md5: 6112b3173f3aa2f12a8f40d07a77cc35
+    sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
+  category: main
+  optional: false
 - name: libzlib
   version: 1.2.13
   manager: conda
@@ -3832,6 +7123,17 @@ package:
   hash:
     md5: f36c115f1ee199da648e0597ec2047ad
     sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 4a3ad23f6e16f99c04e166767193d700
+    sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
   category: main
   optional: false
 - name: libzopfli
@@ -3847,10 +7149,44 @@ package:
     sha256: ff94f30b2e86cbad6296cf3e5804d442d9e881f7ba8080d92170981662528c6e
   category: main
   optional: false
+- name: libzopfli
+  version: 1.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=11.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzopfli-1.0.3-h046ec9c_0.tar.bz2
+  hash:
+    md5: 55f3f5c9bccca18d33cb3a4bcfe002d7
+    sha256: 3f35f8adf997467699a01819aeabba153ef554e796618c446a9626c2173aee90
+  category: main
+  optional: false
 - name: lightning
   version: 2.1.4
   manager: conda
   platform: linux-64
+  dependencies:
+    fsspec: <2025.0,>=2022.5.0
+    lightning-utilities: <2.0,>=0.8.0
+    numpy: <3.0,>=1.17.2
+    packaging: <25.0,>=20.0
+    python: '>=3.8'
+    pytorch: <4.0,>=1.12.0
+    pytorch-lightning: ''
+    pyyaml: <8.0,>=5.4
+    torchmetrics: <3.0,>=0.7.0
+    tqdm: <6.0,>=4.57.0
+    typing-extensions: <6.0,>=4.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-2.1.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: e22ceab1b6986e290410f0be6b26c323
+    sha256: 65eebe30c4612c918c2deeef906db269f69cff0d630d501241b05593a7851065
+  category: main
+  optional: false
+- name: lightning
+  version: 2.1.4
+  manager: conda
+  platform: osx-64
   dependencies:
     fsspec: <2025.0,>=2022.5.0
     lightning-utilities: <2.0,>=0.8.0
@@ -3883,10 +7219,37 @@ package:
     sha256: 3f9505c0cd1b84e0aae8354adcada75cb0f1af09b1005d3168280a6d3c2b74ba
   category: main
   optional: false
+- name: lightning-utilities
+  version: 0.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: '>=17.1'
+    python: '>=3.8'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4132ed16f8074bc111d477c52508fda4
+    sha256: 3f9505c0cd1b84e0aae8354adcada75cb0f1af09b1005d3168280a6d3c2b74ba
+  category: main
+  optional: false
 - name: linkify-it-py
   version: 2.0.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    uc-micro-py: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+    sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  category: main
+  optional: false
+- name: linkify-it-py
+  version: 2.0.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     uc-micro-py: ''
@@ -3909,10 +7272,33 @@ package:
     sha256: 18a9db4cc139e72e8eac80a34f6536491fe318d3785bc2c35fac42cd00676376
   category: main
   optional: false
+- name: llvm-openmp
+  version: 17.0.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
+  hash:
+    md5: f260ab897df05f729fc3e65dbb0850ef
+    sha256: 9ea2f7018f335fdc55bc9b21a388eb94ea47a243d9cbf6ec3d8862d4df9fb49b
+  category: main
+  optional: false
 - name: locket
   version: 1.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 91e27ef3d05cc772ce627e51cff111c4
+    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  category: main
+  optional: false
+- name: locket
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
   url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
@@ -3934,6 +7320,18 @@ package:
     sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
   category: main
   optional: false
+- name: lz4-c
+  version: 1.9.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  hash:
+    md5: aa04f7143228308662696ac24023f991
+    sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  category: main
+  optional: false
 - name: lzo
   version: '2.10'
   manager: conda
@@ -3944,6 +7342,17 @@ package:
   hash:
     md5: bb14fcb13341b81d5eb386423b9d2bac
     sha256: 25d16e6aaa3d0b450e61d0c4fadd7c9fd17f16e2fef09b34507209342d63c9f6
+  category: main
+  optional: false
+- name: lzo
+  version: '2.10'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+  hash:
+    md5: 0b6bca372a95d6c602c7a922e928ce79
+    sha256: c8a9401eff2efbbcc6da03d0066ee85d72402f7658c240e7968c64052a0d0493
   category: main
   optional: false
 - name: magma
@@ -3961,17 +7370,29 @@ package:
   category: main
   optional: false
 - name: markdown-it-py
-  version: 2.2.0
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
     mdurl: '>=0.1,<1'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b2928a6c6d52d7e3562b4a59c3214e3a
-    sha256: 65ed439862c1851463f03a9bc5109992ce3e3e025e9a2d76d13ca19f576eee9f
+    md5: 93a8e71256479c62074356ef6ebf501b
+    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  category: main
+  optional: false
+- name: markdown-it-py
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    mdurl: '>=0.1,<1'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 93a8e71256479c62074356ef6ebf501b
+    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
   category: main
   optional: false
 - name: markupsafe
@@ -3986,6 +7407,19 @@ package:
   hash:
     md5: a322b4185121935c871d201ae00ac143
     sha256: 14912e557a6576e03f65991be89e9d289c6e301921b6ecfb4e7186ba974f453d
+  category: main
+  optional: false
+- name: markupsafe
+  version: 2.1.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py311he705e18_0.conda
+  hash:
+    md5: 75abe7e2e3a0874a49d7c175115f443f
+    sha256: 83a2b764a4946a04e693a4dd8fe5a35bf093a378da9ce18bf0689cd5dcb3c3fe
   category: main
   optional: false
 - name: matplotlib-base
@@ -4015,10 +7449,49 @@ package:
     sha256: 3b1d85d61b2c88e72449c1fb2fb0893522512d0924a50aca608ba58663253907
   category: main
   optional: false
+- name: matplotlib-base
+  version: 3.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.12'
+    certifi: '>=2020.06.20'
+    contourpy: '>=1.0.1'
+    cycler: '>=0.10'
+    fonttools: '>=4.22.0'
+    freetype: '>=2.12.1,<3.0a0'
+    kiwisolver: '>=1.3.1'
+    libcxx: '>=16'
+    numpy: '>=1.23.5,<2.0a0'
+    packaging: '>=20.0'
+    pillow: '>=8'
+    pyparsing: '>=2.3.1'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.7'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.3-py311h6ff1f5f_0.conda
+  hash:
+    md5: 34a8ced9af5c6c771d5c18213151a639
+    sha256: 8b317ebb64621325aa56630989a500c67dedc7512eec892de85fe9c676eadf9a
+  category: main
+  optional: false
 - name: matplotlib-inline
   version: 0.1.6
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    traitlets: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21613793fcc81d944c76c9f2864a7de
+    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  category: main
+  optional: false
+- name: matplotlib-inline
+  version: 0.1.6
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
     traitlets: ''
@@ -4041,10 +7514,35 @@ package:
     sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
   category: main
   optional: false
+- name: mdit-py-plugins
+  version: 0.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    markdown-it-py: '>=1.0.0,<4.0.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6c5358a10873a15398b6f15f60cb5e1f
+    sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
+  category: main
+  optional: false
 - name: mdurl
   version: 0.1.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 776a8dd9e824f77abac30e6ef43a8f7a
+    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  category: main
+  optional: false
+- name: mdurl
+  version: 0.1.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
@@ -4072,10 +7570,40 @@ package:
     sha256: e25d24c4841aa85ed2153f826ae58e56ae4d12704fd9e52005a3d7edfeb3b95a
   category: main
   optional: false
+- name: minizip
+  version: 4.0.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=15'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.4-h37d7099_0.conda
+  hash:
+    md5: 36eb00b2cad8e12ee18683dbd15aeba6
+    sha256: c0be39fda07d913da8dbedc15306a1452780890822a8c04dcc8f46b533ca2908
+  category: main
+  optional: false
 - name: mistune
   version: 3.0.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5cbee699846772cc939bef23a0d524ed
+    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  category: main
+  optional: false
+- name: mistune
+  version: 3.0.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
@@ -4098,10 +7626,35 @@ package:
     sha256: 046073737bf73153b0c39e343b197cdf0b7867d336962369407465a17ea5979a
   category: main
   optional: false
+- name: mkl
+  version: 2022.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=14.0.6'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/mkl-2022.2.1-h44ed08c_16952.conda
+  hash:
+    md5: a51e7035c0075d4341942a5894ef20b9
+    sha256: 70896885df3cf031ac547c42f27384f769f190bc2bfb9e2520a7ef2c34db4806
+  category: main
+  optional: false
 - name: more-itertools
   version: 10.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5c98e9706fdc5328d49a9bf2ce5fb42
+    sha256: 9e49e9484ff279453f0b55323a3f0c7cb97440c74f69eecda1f4ad29fae5cd3c
+  category: main
+  optional: false
+- name: more-itertools
+  version: 10.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -4124,6 +7677,19 @@ package:
     sha256: 2f88965949ba7b4b21e7e5facd62285f7c6efdb17359d1b365c3bb4ecc968d29
   category: main
   optional: false
+- name: mpc
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda
+  hash:
+    md5: c752c0eb6c250919559172c011e5f65b
+    sha256: 2ae945a15c8a984d581dcfb974ad3b5d877a6527de2c95a3363e6b4490b2f312
+  category: main
+  optional: false
 - name: mpfr
   version: 4.2.1
   manager: conda
@@ -4137,10 +7703,34 @@ package:
     sha256: 008230a53ff15cf61966476b44f7ba2c779826825b9ca639a0a2b44d8f7aa6cb
   category: main
   optional: false
+- name: mpfr
+  version: 4.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-h0c69b56_0.conda
+  hash:
+    md5: d545aecded064848432bc994075dfccf
+    sha256: e7c93a5399661b0528981c6fd53e8614eee3f9ba97f92e8167c092c4a5d9368c
+  category: main
+  optional: false
 - name: mpmath
   version: 1.3.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: dbf6e2d89137da32fa6670f3bffc024e
+    sha256: a4f025c712ec1502a55c471b56a640eaeebfce38dd497d5a1a33729014cac47a
+  category: main
+  optional: false
+- name: mpmath
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
@@ -4164,6 +7754,21 @@ package:
     sha256: b12070ce86f108d3dcf2f447dfa76906c4bc15f2d2bf6cef19703ee42768b74a
   category: main
   optional: false
+- name: msgpack-python
+  version: 1.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.7-py311h7bea37d_0.conda
+  hash:
+    md5: a44d3852f8eaab128793074b26d5dcf9
+    sha256: 87de66aee894bf8054c92bfec296bfb2520077cb9f958d043177a782922fcf2b
+  category: main
+  optional: false
 - name: multidict
   version: 6.0.5
   manager: conda
@@ -4176,6 +7781,19 @@ package:
   hash:
     md5: 4288ea5cbe686d1b18fc3efb36c009a5
     sha256: aa20fb2d8ecb16099126ec5607fc12082de4111b5e4882e944f4b6cd846178d9
+  category: main
+  optional: false
+- name: multidict
+  version: 6.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.5-py311h5547dcb_0.conda
+  hash:
+    md5: 163d2cb37b054606283917075809c5be
+    sha256: 6bb2acb8f4c1c25e4bb61421f654559c044af98d409c794cd84ae9fbac031ded
   category: main
   optional: false
 - name: multiprocess
@@ -4193,6 +7811,20 @@ package:
     sha256: eca27e6fb5fb4ee73f04ae030bce29f5daa46fea3d6abdabb91740646f0d188e
   category: main
   optional: false
+- name: multiprocess
+  version: 0.70.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    dill: '>=0.3.6'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/multiprocess-0.70.15-py311h2725bcf_1.conda
+  hash:
+    md5: 2e0b822069c4ccaac39e4988adf82ece
+    sha256: 5c6f1eaa4f509036301b3466425b682c7a9b6dbb17ea71c934ac8a4e55a6a252
+  category: main
+  optional: false
 - name: munkres
   version: 1.1.4
   manager: conda
@@ -4205,67 +7837,162 @@ package:
     sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   category: main
   optional: false
+- name: munkres
+  version: 1.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ba8498c1018c1e9c61eb99b973dfe19
+    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  category: main
+  optional: false
 - name: myst-nb
-  version: 0.17.2
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
     importlib-metadata: ''
     ipykernel: ''
     ipython: ''
-    jupyter-cache: '>=0.5.0,<0.7.0'
-    myst-parser: '>=0.18.0,<0.19.0'
+    jupyter-cache: '>=0.5.0'
+    myst-parser: '>=1.0.0'
     nbclient: ''
-    nbformat: '>=5.0,<6'
-    python: '>=3.7'
+    nbformat: '>=5.0'
+    python: '>=3.9'
     pyyaml: ''
-    sphinx: '>=4,<6'
+    sphinx: '>=5'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.17.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-1.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 40190b7d06f86b63d28fa78aaa39c023
-    sha256: 37bcf6de8618a0668ef6b364b14e0eceea87b202a3882c59dcd85bc1172a5402
+    md5: fe4a9aa4a900dc509fcb5e6210184fa3
+    sha256: b9565fab01faef49911c7c9d0d47ee84e5fb2a247e01020e7801f28eccf922c2
+  category: main
+  optional: false
+- name: myst-nb
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: ''
+    ipykernel: ''
+    ipython: ''
+    jupyter-cache: '>=0.5.0'
+    myst-parser: '>=1.0.0'
+    nbclient: ''
+    nbformat: '>=5.0'
+    python: '>=3.9'
+    pyyaml: ''
+    sphinx: '>=5'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-nb-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: fe4a9aa4a900dc509fcb5e6210184fa3
+    sha256: b9565fab01faef49911c7c9d0d47ee84e5fb2a247e01020e7801f28eccf922c2
   category: main
   optional: false
 - name: myst-parser
-  version: 0.18.1
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    docutils: '>=0.15,<0.20'
+    docutils: '>=0.16,<0.21'
     jinja2: ''
-    markdown-it-py: '>=1.0.0,<3.0.0'
-    mdit-py-plugins: '>=0.3.1,<1'
-    python: '>=3.7'
+    markdown-it-py: '>=3.0.0,<4.0.0'
+    mdit-py-plugins: '>=0.4,<1'
+    python: '>=3.8'
     pyyaml: ''
-    sphinx: '>=4,<6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-0.18.1-pyhd8ed1ab_0.tar.bz2
+    sphinx: '>=6,<8'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bcfdf5c7d8bf5c6f6be7b4c66fff2eca
-    sha256: 260812a430adee3598103d75704c1c855a9816a3895971ca0190d0f5e1e8165a
+    md5: 70699181909e468875f12076e1b0a8a9
+    sha256: 59cdc52d9875f623a4df82896d80f304e436138f8410cbef969a7e4452c6bab7
+  category: main
+  optional: false
+- name: myst-parser
+  version: 2.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    docutils: '>=0.16,<0.21'
+    jinja2: ''
+    markdown-it-py: '>=3.0.0,<4.0.0'
+    mdit-py-plugins: '>=0.4,<1'
+    python: '>=3.8'
+    pyyaml: ''
+    sphinx: '>=6,<8'
+  url: https://conda.anaconda.org/conda-forge/noarch/myst-parser-2.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 70699181909e468875f12076e1b0a8a9
+    sha256: 59cdc52d9875f623a4df82896d80f304e436138f8410cbef969a7e4452c6bab7
   category: main
   optional: false
 - name: nbclient
-  version: 0.7.4
+  version: 0.8.0
   manager: conda
   platform: linux-64
   dependencies:
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
-    python: '>=3.7'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    traitlets: '>=5.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f7aa15f77d29b11caa1df1eb15383c59
-    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
+    md5: e78da91cf428faaf05701ce8cc8f2f9b
+    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
+  category: main
+  optional: false
+- name: nbclient
+  version: 0.8.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
+    python: '>=3.8'
+    traitlets: '>=5.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e78da91cf428faaf05701ce8cc8f2f9b
+    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
   category: main
   optional: false
 - name: nbconvert-core
   version: 7.16.1
   manager: conda
   platform: linux-64
+  dependencies:
+    beautifulsoup4: ''
+    bleach: ''
+    defusedxml: ''
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2537745e9bc0e9bfcf66a27f113ae0e5
+    sha256: 684e0710abd6477ed9df743506edecb4b53d1c9deeaf8d6d7fdbb82e58f43090
+  category: main
+  optional: false
+- name: nbconvert-core
+  version: 7.16.1
+  manager: conda
+  platform: osx-64
   dependencies:
     beautifulsoup4: ''
     bleach: ''
@@ -4306,6 +8033,22 @@ package:
     sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
   category: main
   optional: false
+- name: nbformat
+  version: 5.9.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    jsonschema: '>=2.6'
+    jupyter_core: ''
+    python: '>=3.8'
+    python-fastjsonschema: ''
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 61ba076de6530d9301a0053b02f093d2
+    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
+  category: main
+  optional: false
 - name: nccl
   version: 2.20.3.1
   manager: conda
@@ -4332,10 +8075,34 @@ package:
     sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
   category: main
   optional: false
+- name: ncurses
+  version: '6.4'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  hash:
+    md5: e58f366bd4d767e9ab97ab8b272e7670
+    sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+  category: main
+  optional: false
 - name: nest-asyncio
   version: 1.6.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6598c056f64dc8800d40add25e4e2c34
+    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  category: main
+  optional: false
+- name: nest-asyncio
+  version: 1.6.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
@@ -4356,10 +8123,35 @@ package:
     sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
   category: main
   optional: false
+- name: networkx
+  version: 3.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 425fce3b531bed6ec3c74fab3e5f0a1c
+    sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
+  category: main
+  optional: false
 - name: notebook-shim
   version: 0.2.4
   manager: conda
   platform: linux-64
+  dependencies:
+    jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d85618e2c97ab896b5b5e298d32b5b3
+    sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  category: main
+  optional: false
+- name: notebook-shim
+  version: 0.2.4
+  manager: conda
+  platform: osx-64
   dependencies:
     jupyter_server: '>=1.8,<3'
     python: '>=3.7'
@@ -4382,6 +8174,18 @@ package:
     sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
   category: main
   optional: false
+- name: nspr
+  version: '4.35'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  hash:
+    md5: a9e56c98d13d8b7ce72bf4357317c29b
+    sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
+  category: main
+  optional: false
 - name: nss
   version: '3.98'
   manager: conda
@@ -4399,6 +8203,21 @@ package:
     sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
   category: main
   optional: false
+- name: nss
+  version: '3.98'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    nspr: '>=4.35,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
+  hash:
+    md5: 79d062716d8e1f77cf806c6fe0f4405c
+    sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
+  category: main
+  optional: false
 - name: numcodecs
   version: 0.12.1
   manager: conda
@@ -4414,6 +8233,23 @@ package:
   hash:
     md5: 38a2ff8ea433fe8792279b45e84b3730
     sha256: 955364f88de712e63ae824736d88d20cfb06df3be464351ccebdc84cb42ef854
+  category: main
+  optional: false
+- name: numcodecs
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    msgpack-python: ''
+    numpy: '>=1.7'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py311hd39e593_0.conda
+  hash:
+    md5: 24d581420696962d46124d537f895dc6
+    sha256: e72b8c92f92a2c49ee1168dc8f5c353d2e0f9e5ef96a72bc494346c46c63027a
   category: main
   optional: false
 - name: numpy
@@ -4434,6 +8270,23 @@ package:
     sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
   category: main
   optional: false
+- name: numpy
+  version: 1.26.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=16'
+    liblapack: '>=3.9.0,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+  hash:
+    md5: bb02b8801d17265160e466cf8bbf28da
+    sha256: dc9628197125ee1d02b2e7a859a769d26291d747ed79337309b8a9e67a8b8e00
+  category: main
+  optional: false
 - name: openjpeg
   version: 2.5.0
   manager: conda
@@ -4450,6 +8303,21 @@ package:
     sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
   category: main
   optional: false
+- name: openjpeg
+  version: 2.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  hash:
+    md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+    sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+  category: main
+  optional: false
 - name: openssl
   version: 3.2.1
   manager: conda
@@ -4461,6 +8329,18 @@ package:
   hash:
     md5: 51a753e64a3027bd7e23a189b1f6e91e
     sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+  category: main
+  optional: false
+- name: openssl
+  version: 3.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
+  hash:
+    md5: 3033be9a59fd744172b03971b9ccd081
+    sha256: 20c1b1a34a1831c24d37ed1500ca07300171184af0c66598f3c5ca901634d713
   category: main
   optional: false
 - name: orc
@@ -4481,10 +8361,41 @@ package:
     sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
   category: main
   optional: false
+- name: orc
+  version: 1.9.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+  hash:
+    md5: 8fb76f7b135aec885cfe47c52b2eb4b5
+    sha256: a948db80c0b756db07abce1972d6b8d1a08a7ced5a687b02435348c81443de08
+  category: main
+  optional: false
 - name: overrides
   version: 7.7.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    typing_utils: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  category: main
+  optional: false
+- name: overrides
+  version: 7.7.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
     typing_utils: ''
@@ -4506,8 +8417,20 @@ package:
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   category: main
   optional: false
+- name: packaging
+  version: '23.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  category: main
+  optional: false
 - name: pandas
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4519,10 +8442,28 @@ package:
     python-tzdata: '>=2022a'
     python_abi: 3.11.*
     pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.0-py311h320fe9a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py311h320fe9a_0.conda
   hash:
-    md5: b9e7a2cb2c47bbb99c05d1892500be45
-    sha256: 2198fb053d15ac5e1ea73990b6a1d6a08b4312bbb3364890cfd7d984840119e9
+    md5: aac8d7137fedc2fd5f8320bf50e4204c
+    sha256: ce9e6dab534466e04c5d09cc341a5e2ee6b0ef8eaa05052b22484582919cd38c
+  category: main
+  optional: false
+- name: pandas
+  version: 2.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=16'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.8.1'
+    python-tzdata: '>=2022a'
+    python_abi: 3.11.*
+    pytz: '>=2020.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.1-py311h8f6166a_0.conda
+  hash:
+    md5: bc816098a39b339c3d09da63405478bf
+    sha256: 455f1fd9e78a0c411529d81fac40a874af464ad2a0aae33f3fa8767f4ab7be7b
   category: main
   optional: false
 - name: pandocfilters
@@ -4537,10 +8478,34 @@ package:
     sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   category: main
   optional: false
+- name: pandocfilters
+  version: 1.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '!=3.0,!=3.1,!=3.2,!=3.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 457c2c8c08e54905d6954e79cb5b5db9
+    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  category: main
+  optional: false
 - name: parso
   version: 0.8.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 17a565a0c3899244e938cdf417e7b094
+    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  category: main
+  optional: false
+- name: parso
+  version: 0.8.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
@@ -4563,6 +8528,20 @@ package:
     sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
   category: main
   optional: false
+- name: partd
+  version: 1.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    locket: ''
+    python: '>=3.7'
+    toolz: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
+    sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+  category: main
+  optional: false
 - name: pastel
   version: 0.2.1
   manager: conda
@@ -4575,10 +8554,34 @@ package:
     sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
   category: main
   optional: false
+- name: pastel
+  version: 0.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: a4eea5bff523f26442405bc5d1f52adb
+    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
+  category: main
+  optional: false
 - name: pathtools
   version: 0.1.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pathtools-0.1.2-py_1.tar.bz2
+  hash:
+    md5: 7c9b5632c61951216374dbaa34659301
+    sha256: d11dab35f9a669458d93f71a28158517a7624405c9cbe665aa60cb3ffb01de4b
+  category: main
+  optional: false
+- name: pathtools
+  version: 0.1.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pathtools-0.1.2-py_1.tar.bz2
@@ -4601,6 +8604,19 @@ package:
     sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
   category: main
   optional: false
+- name: pcre2
+  version: '10.42'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
+  hash:
+    md5: 41de8bab2d5e5cd6daaba1896e81d366
+    sha256: 689559d94b64914e503d2ced53b78afc19562ed1ccfb284040797a6d41bb564c
+  category: main
+  optional: false
 - name: pexpect
   version: 4.9.0
   manager: conda
@@ -4614,10 +8630,35 @@ package:
     sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
   category: main
   optional: false
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ptyprocess: '>=0.5'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: main
+  optional: false
 - name: pickleshare
   version: 0.7.5
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  hash:
+    md5: 415f0ebb6198cc2801c73438a9fb5761
+    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  category: main
+  optional: false
+- name: pickleshare
+  version: 0.7.5
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3'
   url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
@@ -4649,6 +8690,28 @@ package:
     sha256: 3cd4827d822c9888b672bfac9017e905348ac5bd2237a98b30a734ed6573b248
   category: main
   optional: false
+- name: pillow
+  version: 10.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.2.0-py311hea5c87a_0.conda
+  hash:
+    md5: 1709b31ce50343c7a7b3940ed30cc429
+    sha256: c3f3d2276943d5bf27d184df76dcef15ad120d23f9eea92e05340093acee98fc
+  category: main
+  optional: false
 - name: pixman
   version: 0.43.2
   manager: conda
@@ -4660,6 +8723,18 @@ package:
   hash:
     md5: 71004cbf7924e19c02746ccde9fd7123
     sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  category: main
+  optional: false
+- name: pixman
+  version: 0.43.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
+  hash:
+    md5: 26cf3be47886ded561d3d2cd8654893f
+    sha256: 26b16d9a6aed8f3d96a7dbad5d63b6ab1bcce13d77c050bcbaf7378bada2d225
   category: main
   optional: false
 - name: pkginfo
@@ -4674,10 +8749,34 @@ package:
     sha256: 7ea5a5af62a15376d9f4f9f3c134874d0b0710f39be719e849b7fa9ca8870502
   category: main
   optional: false
+- name: pkginfo
+  version: 1.9.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: be1e9f1c65a1ed0f2ae9352fec99db64
+    sha256: 7ea5a5af62a15376d9f4f9f3c134874d0b0710f39be719e849b7fa9ca8870502
+  category: main
+  optional: false
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  hash:
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  category: main
+  optional: false
+- name: pkgutil-resolve-name
+  version: 1.3.10
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
@@ -4706,10 +8805,42 @@ package:
     sha256: 672833457cac1a934400b5ef9f5f77d2175b84096ec3a057b33e599c4bacd1b9
   category: main
   optional: false
+- name: planetary-computer
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=7.1'
+    packaging: ''
+    pydantic: '>=1.7.3'
+    pystac: '>=1.0.0'
+    pystac-client: '>=0.2.0'
+    python: '>=3.7'
+    python-dotenv: ''
+    pytz: '>=2020.5'
+    requests: '>=2.25.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: bcd66071f31063cd200f0ba4620a9926
+    sha256: 672833457cac1a934400b5ef9f5f77d2175b84096ec3a057b33e599c4bacd1b9
+  category: main
+  optional: false
 - name: platformdirs
   version: 4.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a0bc3eec34b0fab84be6b2da94e98e20
+    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
+  category: main
+  optional: false
+- name: platformdirs
+  version: 4.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
@@ -4747,10 +8878,50 @@ package:
     sha256: 55bb2deb67c76bd9f5592bf9765cc879cf11e555c4f8879292cbd5544e88887e
   category: main
   optional: false
+- name: poppler
+  version: 24.02.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libglib: '>=2.78.3,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.42,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    nspr: '>=4.35,<5.0a0'
+    nss: '>=3.97,<4.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
+    poppler-data: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.02.0-h0c752f9_0.conda
+  hash:
+    md5: 064e1d83d148b0ff5fa9ddd21141d0b1
+    sha256: 54400c2961eca96f14ecbb9ccdac457ef7f86ee6741e38aa71db47eee22b76b6
+  category: main
+  optional: false
 - name: poppler-data
   version: 0.4.12
   manager: conda
   platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  hash:
+    md5: d8d7293c5b37f39b2ac32940621c6592
+    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  category: main
+  optional: false
+- name: poppler-data
+  version: 0.4.12
+  manager: conda
+  platform: osx-64
   dependencies: {}
   url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
   hash:
@@ -4778,6 +8949,25 @@ package:
     sha256: 5b4fcfbd51957bb51fb1d2d28c3e9d8f4a50be0ac1be9c40083b1e9a39df7f3d
   category: main
   optional: false
+- name: postgresql
+  version: '16.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    krb5: '>=1.21.2,<1.22.0a0'
+    libpq: '16.2'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tzcode: ''
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-hbd19fd8_0.conda
+  hash:
+    md5: 00ed2daaa212835979fedc2cb7e1eac7
+    sha256: 8a9d1277488ee4c7e7c260d9423280782497930253a56bc9d88c94b2ec59748f
+  category: main
+  optional: false
 - name: proj
   version: 9.3.1
   manager: conda
@@ -4795,6 +8985,23 @@ package:
     sha256: 234f8f7b255dc9036812ec30d097c0725047f3fc7e8e0bc7944e4e17d242ab99
   category: main
   optional: false
+- name: proj
+  version: 9.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcurl: '>=8.4.0,<9.0a0'
+    libcxx: '>=16.0.6'
+    libsqlite: '>=3.44.2,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    sqlite: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.1-h81faed2_0.conda
+  hash:
+    md5: 3940ef505861767d26659645f9ec0460
+    sha256: 51bc021e25c88a12151d6ab4d3e956e72ea21d2684315f6ea99ee699aaefc1ea
+  category: main
+  optional: false
 - name: prometheus_client
   version: 0.20.0
   manager: conda
@@ -4807,10 +9014,35 @@ package:
     sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
   category: main
   optional: false
+- name: prometheus_client
+  version: 0.20.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9a19b94034dd3abb2b348c8b93388035
+    sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
+  category: main
+  optional: false
 - name: prompt-toolkit
   version: 3.0.42
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    wcwidth: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
+  hash:
+    md5: 0bf64bf10eee21f46ac83c161917fa86
+    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
+  category: main
+  optional: false
+- name: prompt-toolkit
+  version: 3.0.42
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
     wcwidth: ''
@@ -4838,6 +9070,24 @@ package:
     sha256: 1f664f5fc370c28809024387e2f991003fcabf8b025c787c70dbc99a8fcb2088
   category: main
   optional: false
+- name: protobuf
+  version: 4.24.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcxx: '>=16.0.6'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.24.4-py311h021eaf5_0.conda
+  hash:
+    md5: f8105062d22f61505797d78890b5ca75
+    sha256: 2d6e0a1681d8ce871d8a6e2a0f40ad48c14d2a3df19a8012e95a4e33ddddcde6
+  category: main
+  optional: false
 - name: psutil
   version: 5.9.8
   manager: conda
@@ -4852,6 +9102,19 @@ package:
     sha256: 467788418a2c71fb3df9ac0a6282ae693d1070a6cb47cb59bdb529b53acaee1c
   category: main
   optional: false
+- name: psutil
+  version: 5.9.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py311he705e18_0.conda
+  hash:
+    md5: 31aa294c58b3058c179a7a9593e99e18
+    sha256: fcff83f4d265294b54821656a10be62421da377885ab2e9811a80eb76419b3fe
+  category: main
+  optional: false
 - name: pthread-stubs
   version: '0.4'
   manager: conda
@@ -4862,6 +9125,17 @@ package:
   hash:
     md5: 22dad4df6e8630e8dff2428f6f6a7036
     sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  category: main
+  optional: false
+- name: pthread-stubs
+  version: '0.4'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  hash:
+    md5: addd19059de62181cd11ae8f4ef26084
+    sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
   category: main
   optional: false
 - name: ptyprocess
@@ -4876,10 +9150,34 @@ package:
     sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
   category: main
   optional: false
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: main
+  optional: false
 - name: pure_eval
   version: 0.2.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 6784285c7e55cb7212efabc79e4c2883
+    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  category: main
+  optional: false
+- name: pure_eval
+  version: 0.2.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
@@ -4912,6 +9210,29 @@ package:
     sha256: f173e58d65d7fda274097f072beed851eb0b99b239a89b4e5c92a37168b395fd
   category: main
   optional: false
+- name: pyarrow
+  version: 15.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow: 15.0.0
+    libarrow-acero: 15.0.0
+    libarrow-dataset: 15.0.0
+    libarrow-flight: 15.0.0
+    libarrow-flight-sql: 15.0.0
+    libarrow-gandiva: 15.0.0
+    libarrow-substrait: 15.0.0
+    libcxx: '>=14'
+    libparquet: 15.0.0
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.0-py311h54e7ce8_0_cpu.conda
+  hash:
+    md5: 004c52abb088437d670d353208196b6c
+    sha256: 965dafaa9e341c0077bffa4beab361e3ecc6e285e5282c9ca1118fe694ed0e11
+  category: main
+  optional: false
 - name: pyarrow-hotfix
   version: '0.6'
   manager: conda
@@ -4925,10 +9246,39 @@ package:
     sha256: 9b767969d059c106aac6596438a7e7ebd3aa1e2ff6553d4b7e05126dfebf4bd6
   category: main
   optional: false
+- name: pyarrow-hotfix
+  version: '0.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyarrow: '>=0.14'
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: ccc06e6ef2064ae129fab3286299abda
+    sha256: 9b767969d059c106aac6596438a7e7ebd3aa1e2ff6553d4b7e05126dfebf4bd6
+  category: main
+  optional: false
 - name: pybtex
   version: 0.24.0
   manager: conda
   platform: linux-64
+  dependencies:
+    latexcodec: '>=1.0.4'
+    python: '>=3.6'
+    pyyaml: '>=3.01'
+    setuptools: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.24.0-pyhd8ed1ab_2.tar.bz2
+  hash:
+    md5: 2099b86a7399c44c0c61cdb6de6915ba
+    sha256: 258fbf46050bbd51fbaa504116e56e8f3064156f0e08cad4e2fec97f5f29e6dc
+  category: main
+  optional: false
+- name: pybtex
+  version: 0.24.0
+  manager: conda
+  platform: osx-64
   dependencies:
     latexcodec: '>=1.0.4'
     python: '>=3.6'
@@ -4957,10 +9307,38 @@ package:
     sha256: 2b7057a1529e190689c141d4a76a7ae2f9f978870737d7e11c3a8e03ad5b27cb
   category: main
   optional: false
+- name: pybtex-docutils
+  version: 1.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    docutils: '>=0.14'
+    pybtex: '>=0.16'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pybtex-docutils-1.0.3-py311h6eed73b_1.conda
+  hash:
+    md5: 36996441974a061f9e0b600741599585
+    sha256: 13b6ee67378fee966f8783cb482ce57a647ee0c6d7d1e7dedee754408521641f
+  category: main
+  optional: false
 - name: pycparser
   version: '2.21'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: 2.7.*|>=3.4
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 076becd9e05608f8dc72757d5f3a91ff
+    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  category: main
+  optional: false
+- name: pycparser
+  version: '2.21'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: 2.7.*|>=3.4
   url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
@@ -4984,10 +9362,44 @@ package:
     sha256: f2d3a838fc90699c5dcd537aff10c78b33bd755232d0b21b26247cbf185cced7
   category: main
   optional: false
+- name: pydantic
+  version: 1.10.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    typing-extensions: '>=4.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-1.10.13-py311he705e18_1.conda
+  hash:
+    md5: ca0cd7b41964ce9a7b80290ea85e22e9
+    sha256: c55ab5f7d182421a5c11f70afc32425fa192f1e40de5c301f685b25bdc3391a8
+  category: main
+  optional: false
 - name: pydata-sphinx-theme
   version: 0.15.2
   manager: conda
   platform: linux-64
+  dependencies:
+    accessible-pygments: ''
+    babel: ''
+    beautifulsoup4: ''
+    docutils: '!=0.17.0'
+    packaging: ''
+    pygments: '>=2.7'
+    python: '>=3.9'
+    sphinx: '>=5.0'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: ce99859070b0e17ccc63234ca58f3ed8
+    sha256: 7046e72770e549f8f22865be737f3f8d0f49f11a5894fe48ccf44611941dba5a
+  category: main
+  optional: false
+- name: pydata-sphinx-theme
+  version: 0.15.2
+  manager: conda
+  platform: osx-64
   dependencies:
     accessible-pygments: ''
     babel: ''
@@ -5016,6 +9428,18 @@ package:
     sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
   category: main
   optional: false
+- name: pygments
+  version: 2.17.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 140a7f159396547e9799aa98f9f0742e
+    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
+  category: main
+  optional: false
 - name: pylev
   version: 1.4.0
   manager: conda
@@ -5028,10 +9452,64 @@ package:
     sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
   category: main
   optional: false
+- name: pylev
+  version: 1.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/pylev-1.4.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: edf8651c4379d9d1495ad6229622d150
+    sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
+  category: main
+  optional: false
+- name: pyobjc-core
+  version: '10.1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.1-py311h9b70068_0.conda
+  hash:
+    md5: e5a3b39d0ad3ec4cad4438ca51ce6a65
+    sha256: b3c7c35b52460bf64cf7854ea5dc083370419f16f3b4d5b16081be623bc52118
+  category: main
+  optional: false
+- name: pyobjc-framework-cocoa
+  version: '10.1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pyobjc-core: 10.1.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.1-py311h9b70068_0.conda
+  hash:
+    md5: 03de24825bd26bf77746aa3eacb6f980
+    sha256: 0062a6ec46b41845a97ca689e056e010fba98a0deaec0ff5d7dfe47eb14ccec4
+  category: main
+  optional: false
 - name: pyparsing
   version: 3.1.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  category: main
+  optional: false
+- name: pyparsing
+  version: 3.1.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
@@ -5056,10 +9534,38 @@ package:
     sha256: 268f77203171d4711d1264fa5fa0e7b066362e7f7c72753deb8c4d40fd40e55b
   category: main
   optional: false
+- name: pyproj
+  version: 3.6.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    certifi: ''
+    proj: '>=9.3.1,<9.3.2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311hb91e5a3_5.conda
+  hash:
+    md5: 08bdce93070973621ff5416d297196e4
+    sha256: 1a8a0634cd1ae9fe7935614cb6e9c8ade72821c5361365f83a4a8d368e7f373c
+  category: main
+  optional: false
 - name: pysocks
   version: 1.7.1
   manager: conda
   platform: linux-64
+  dependencies:
+    __unix: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  hash:
+    md5: 2a7de29fb590ca14b5243c4c812c8025
+    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  category: main
+  optional: false
+- name: pysocks
+  version: 1.7.1
+  manager: conda
+  platform: osx-64
   dependencies:
     __unix: ''
     python: '>=3.8'
@@ -5082,10 +9588,38 @@ package:
     sha256: 323e28b957667bf80d8c6af6464afb0e849017cf3d46029c260ce0f1ccc3df0f
   category: main
   optional: false
+- name: pystac
+  version: 1.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    python-dateutil: '>=2.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0282b584c5853a0532f0418c6d3f4d82
+    sha256: 323e28b957667bf80d8c6af6464afb0e849017cf3d46029c260ce0f1ccc3df0f
+  category: main
+  optional: false
 - name: pystac-client
   version: 0.7.5
   manager: conda
   platform: linux-64
+  dependencies:
+    pystac: '>=1.8.2'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    requests: '>=2.28.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.7.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: b6f96434f84ab0be034166b1bb075fe1
+    sha256: c984dab4569898d292936cb83f0ad9f9e5a9e2acb526c24cadc25a3de0ab17ca
+  category: main
+  optional: false
+- name: pystac-client
+  version: 0.7.5
+  manager: conda
+  platform: osx-64
   dependencies:
     pystac: '>=1.8.2'
     python: '>=3.8'
@@ -5124,10 +9658,45 @@ package:
     sha256: f33559d7127b6a892854bc3b2b4be1406c3be9537d658cb13edae57c8c0b5a11
   category: main
   optional: false
+- name: python
+  version: 3.11.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.8-h9f0c242_0_cpython.conda
+  hash:
+    md5: 22bda10a0f425564a538aed9a0e8a9df
+    sha256: 645dad20b46041ecd6a85eccbb3291fa1ad7921eea065c0081efff78c3d7e27a
+  category: main
+  optional: false
 - name: python-dateutil
   version: 2.8.2
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: dd999d1cc9f79e67dbb855c8924c7984
+    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  category: main
+  optional: false
+- name: python-dateutil
+  version: 2.8.2
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
     six: '>=1.5'
@@ -5149,10 +9718,34 @@ package:
     sha256: 2d4c80364f03315d606a50eddd493dbacc078e21412c2462c0f781eec49b572c
   category: main
   optional: false
+- name: python-dotenv
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c2997ea9360ac4e015658804a7a84f94
+    sha256: 2d4c80364f03315d606a50eddd493dbacc078e21412c2462c0f781eec49b572c
+  category: main
+  optional: false
 - name: python-fastjsonschema
   version: 2.19.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
+    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
+  category: main
+  optional: false
+- name: python-fastjsonschema
+  version: 2.19.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.3'
   url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
@@ -5173,10 +9766,34 @@ package:
     sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
   category: main
   optional: false
+- name: python-json-logger
+  version: 2.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: a61bf9ec79426938ff785eb69dbb1960
+    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  category: main
+  optional: false
 - name: python-tzdata
   version: '2024.1'
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 98206ea9954216ee7540f0c773f2104d
+    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+  category: main
+  optional: false
+- name: python-tzdata
+  version: '2024.1'
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -5200,6 +9817,20 @@ package:
     sha256: 91293b2ca0f36ac580f2be4b9c0858cdaec52eff95473841231dcd044acd2e12
   category: main
   optional: false
+- name: python-xxhash
+  version: 3.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    xxhash: '>=0.8.2,<0.8.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-xxhash-3.4.1-py311h2725bcf_0.conda
+  hash:
+    md5: cf0c4b7e8917c3622f094ab5cf6fca48
+    sha256: eabe88773661e591bf3fdd7e912c2993eda09643e295fc1352a2c299195e2976
+  category: main
+  optional: false
 - name: python_abi
   version: '3.11'
   manager: conda
@@ -5209,6 +9840,17 @@ package:
   hash:
     md5: d786502c97404c94d7d58d258a445a65
     sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.11'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: fef7a52f0eca6bae9e8e2e255bc86394
+    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
   category: main
   optional: false
 - name: pytorch
@@ -5256,10 +9898,61 @@ package:
     sha256: 6545f20bd1aad338df6eece340c190a28979cb12cb0497e047b91a2bf076ed56
   category: main
   optional: false
+- name: pytorch
+  version: 2.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    filelock: ''
+    fsspec: ''
+    jinja2: ''
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=15.0.7'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libuv: '>=1.46.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
+    mkl: '>=2022.2.1,<2023.0a0'
+    networkx: ''
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
+    sympy: ''
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.1.0-cpu_mkl_py311h5cbed28_100.conda
+  hash:
+    md5: 2535973ec977b25dad4511eee8e2ab73
+    sha256: ba8a77b9a9f9ae31173d186e70ebae9a6b605620d1f876284bc9139a970e48e8
+  category: main
+  optional: false
 - name: pytorch-lightning
   version: 2.1.3
   manager: conda
   platform: linux-64
+  dependencies:
+    fsspec: '>=2022.5.0'
+    lightning-utilities: '>=0.8.0'
+    numpy: '>=1.17.2'
+    packaging: '>=20.0'
+    python: '>=3.8'
+    pytorch: '>=1.12.0'
+    pyyaml: '>=5.4'
+    requests: ''
+    torchmetrics: '>=0.7.0'
+    tqdm: '>=4.57.0'
+    typing-extensions: '>=4.0.0'
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-2.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6cb9d53de00b53b4ec5722c96023e43d
+    sha256: 47fbd62a00fe98eee309b4b3ab88ddd8b48005032b19fe03fb3d1cca1503840f
+  category: main
+  optional: false
+- name: pytorch-lightning
+  version: 2.1.3
+  manager: conda
+  platform: osx-64
   dependencies:
     fsspec: '>=2022.5.0'
     lightning-utilities: '>=0.8.0'
@@ -5291,6 +9984,18 @@ package:
     sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
+- name: pytz
+  version: '2024.1'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+    sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  category: main
+  optional: false
 - name: pywavelets
   version: 1.4.1
   manager: conda
@@ -5304,6 +10009,20 @@ package:
   hash:
     md5: 86b71ff85f3e4c8a98b5bace6d9c4565
     sha256: 6f4055f77b16e0e9c2d65d587d7522db4de2f2ed8bc223d067ac4c5223795cc6
+  category: main
+  optional: false
+- name: pywavelets
+  version: 1.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pywavelets-1.4.1-py311h4a70a88_1.conda
+  hash:
+    md5: ed262e580985d97454af994ef6a59cb6
+    sha256: 567fd7db6eab4052c1bcdd84ec8946fa2d8af3268b3eec99a81ee308c17cc34a
   category: main
   optional: false
 - name: pyyaml
@@ -5321,6 +10040,20 @@ package:
     sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
   category: main
   optional: false
+- name: pyyaml
+  version: 6.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    yaml: '>=0.2.5,<0.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
+  hash:
+    md5: 9283f991b5e5856a99f8aabba9927df5
+    sha256: 8ce2ba443414170a2570514d0ce6d03625a847e91af9763d48dc58c338e6f7f3
+  category: main
+  optional: false
 - name: pyzmq
   version: 25.1.2
   manager: conda
@@ -5336,6 +10069,23 @@ package:
   hash:
     md5: 819aa640a0493d4b52faf938e94d129e
     sha256: 54ccdde1370d8a373e516b84bd7fe4af394f8c6f3778eb050de82f04ffb86160
+  category: main
+  optional: false
+- name: pyzmq
+  version: 25.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    zeromq: '>=4.3.5,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.2-py311h889d6d6_0.conda
+  hash:
+    md5: 241fde77a74bd223562662af26f4828b
+    sha256: a8cb598edd68b3d2ca88cd2cdbc60c9180a392c393dd58aaf25e9897697d28d3
   category: main
   optional: false
 - name: rasterio
@@ -5364,6 +10114,31 @@ package:
     sha256: ff98df399442f9e9f2848a5073a4e1a92607947639e31fc43f4eb7897c948977
   category: main
   optional: false
+- name: rasterio
+  version: 1.3.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    affine: ''
+    attrs: ''
+    certifi: ''
+    click: '>=4'
+    click-plugins: ''
+    cligj: '>=0.5'
+    libcxx: '>=15'
+    libgdal: '>=3.8.1,<3.9.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    proj: '>=9.3.1,<9.3.2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: '>=0.9.8'
+    snuggs: '>=1.4.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.9-py311hf358cda_2.conda
+  hash:
+    md5: 8ec98217d793ad5f338cf7c6a2656d43
+    sha256: 376bfd5b7913676e93da7ee069c122cfc2ca6994f8dfa5bc5298af7f4cd4b88f
+  category: main
+  optional: false
 - name: rav1e
   version: 0.6.6
   manager: conda
@@ -5374,6 +10149,17 @@ package:
   hash:
     md5: 77d9955b4abddb811cb8ab1aa7d743e4
     sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  category: main
+  optional: false
+- name: rav1e
+  version: 0.6.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+  hash:
+    md5: ab03527926f8ce85f84a91fd35520ef2
+    sha256: 046ac50530590cd2a5d9bcb1e581bdd168e06049230ad3afd8cce2fa71b429d9
   category: main
   optional: false
 - name: rdma-core
@@ -5403,6 +10189,18 @@ package:
     sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
   category: main
   optional: false
+- name: re2
+  version: 2023.06.02
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libre2-11: 2023.06.02
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+  hash:
+    md5: e498042c254db56d398b6ee858888b9d
+    sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
+  category: main
+  optional: false
 - name: readline
   version: '8.2'
   manager: conda
@@ -5416,10 +10214,36 @@ package:
     sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   category: main
   optional: false
+- name: readline
+  version: '8.2'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.3,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  hash:
+    md5: f17f77f2acf4d344734bda76829ce14e
+    sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  category: main
+  optional: false
 - name: referencing
   version: 0.33.0
   manager: conda
   platform: linux-64
+  dependencies:
+    attrs: '>=22.2.0'
+    python: '>=3.8'
+    rpds-py: '>=0.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: bc415a1c6cf049166215d6b596e0fcbe
+    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
+  category: main
+  optional: false
+- name: referencing
+  version: 0.33.0
+  manager: conda
+  platform: osx-64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
@@ -5444,10 +10268,39 @@ package:
     sha256: 30791fca4461b858bbf4058eba60cc151c38fbd4f883dea72d1d1c5ee4c1ef0a
   category: main
   optional: false
+- name: regex
+  version: 2023.12.25
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/regex-2023.12.25-py311he705e18_0.conda
+  hash:
+    md5: edd197b5c6f97924e578ae39b8d5dd2e
+    sha256: 7ca3b12b00dd2a55dc28a4eed207c4dc15b825f44a8c89c307094ad3448710af
+  category: main
+  optional: false
 - name: requests
   version: 2.31.0
   manager: conda
   platform: linux-64
+  dependencies:
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a30144e4156cdbb236f99ebb49828f8b
+    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  category: main
+  optional: false
+- name: requests
+  version: 2.31.0
+  manager: conda
+  platform: osx-64
   dependencies:
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
@@ -5473,6 +10326,19 @@ package:
     sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
   category: main
   optional: false
+- name: rfc3339-validator
+  version: 0.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: fed45fc5ea0813240707998abe49f520
+    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  category: main
+  optional: false
 - name: rfc3986-validator
   version: 0.1.1
   manager: conda
@@ -5485,10 +10351,40 @@ package:
     sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
   category: main
   optional: false
+- name: rfc3986-validator
+  version: 0.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 912a71cc01012ee38e6b90ddd561e36f
+    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  category: main
+  optional: false
 - name: rioxarray
   version: 0.15.1
   manager: conda
   platform: linux-64
+  dependencies:
+    numpy: '>=1.23'
+    packaging: ''
+    pyproj: '>=3.3'
+    python: '>=3.10'
+    rasterio: '>=1.3'
+    scipy: ''
+    xarray: '>=2022.3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ee15f68451f316e24e76b48f2b98aeb
+    sha256: 534c4792376ca1face1f51e0d386c9d84ac5f511631373276531addc423215cc
+  category: main
+  optional: false
+- name: rioxarray
+  version: 0.15.1
+  manager: conda
+  platform: osx-64
   dependencies:
     numpy: '>=1.23'
     packaging: ''
@@ -5517,6 +10413,19 @@ package:
     sha256: 37d8f344b080ddceb5f1c6224049c2123e65c5d10eddd5b6e6284c8ac6044bb1
   category: main
   optional: false
+- name: rpds-py
+  version: 0.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.18.0-py311hd64b9fd_0.conda
+  hash:
+    md5: 18f9280b452bd1557e98147d53cd4276
+    sha256: 4183fe5ebf84a707efe71abcb6e6f78646483dcb1a6958bf182eca771196a7d2
+  category: main
+  optional: false
 - name: ruamel.yaml
   version: 0.18.6
   manager: conda
@@ -5532,6 +10441,20 @@ package:
     sha256: b7056cf0f680a70c24d0a9addea6e8b640bfeafda4c37887e276331757404da0
   category: main
   optional: false
+- name: ruamel.yaml
+  version: 0.18.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ruamel.yaml.clib: '>=0.1.2'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.6-py311he705e18_0.conda
+  hash:
+    md5: 7a3e388f29ca1862754f89b6d79de335
+    sha256: 64b13898feefe6b98b776a8a0fff05163dad116c643b946a611ae895edcf435b
+  category: main
+  optional: false
 - name: ruamel.yaml.clib
   version: 0.2.8
   manager: conda
@@ -5544,6 +10467,19 @@ package:
   hash:
     md5: 7865c897d89a39abc0056d89e37bd9e9
     sha256: b6a4b72ec2a59de0307fca0c699da6238391ee20deb2d121780d10559b5a61a3
+  category: main
+  optional: false
+- name: ruamel.yaml.clib
+  version: 0.2.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311he705e18_0.conda
+  hash:
+    md5: 3fdbde273667047893775e077cef290d
+    sha256: e6d5b2c9a75191305c8d367d13218c0bd0cc7a640ae776b541124c0fe8341bc9
   category: main
   optional: false
 - name: s2n
@@ -5576,6 +10512,23 @@ package:
     sha256: 2fdc52c648c0a0d80f2f6f484cd0933f9b553d2e568bf8b63abe444974eb75b5
   category: main
   optional: false
+- name: sacremoses
+  version: 0.0.53
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: ''
+    joblib: ''
+    python: '>=3.6'
+    regex: ''
+    six: ''
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sacremoses-0.0.53-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 76c3c384fe0941f1b08193736e8e277a
+    sha256: 2fdc52c648c0a0d80f2f6f484cd0933f9b553d2e568bf8b63abe444974eb75b5
+  category: main
+  optional: false
 - name: safetensors
   version: 0.4.2
   manager: conda
@@ -5588,6 +10541,20 @@ package:
   hash:
     md5: 383129ce71b30f7ad3cc7687d3b461a3
     sha256: 9e34cc5f1a5cf533b0a79ac1c1f10eccb02134af3d6c3da4b352f888da184363
+  category: main
+  optional: false
+- name: safetensors
+  version: 0.4.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/safetensors-0.4.2-py311hb69cc6a_0.conda
+  hash:
+    md5: cb3070b331a27cdeefac5300f595c97f
+    sha256: 5e392fe71b81f900e6e8a09319cdf79bbb70a1c5099b190c5b39902e0e4d9e7d
   category: main
   optional: false
 - name: scikit-image
@@ -5614,6 +10581,30 @@ package:
     sha256: a7ef0c71a7defbc87b5ece4592624aeeab6424dc199795fa3de61a0d69c5b8ae
   category: main
   optional: false
+- name: scikit-image
+  version: 0.22.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    imageio: '>=2.27'
+    lazy_loader: '>=0.2'
+    libcxx: '>=16.0.6'
+    networkx: '>=2.8'
+    numpy: '>=1.23.5,<2.0a0'
+    packaging: '>=21'
+    pillow: '>=9.0.1'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    pywavelets: '>=1.1.1'
+    scipy: '>=1.8'
+    tifffile: '>=2022.8.12'
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-image-0.22.0-py311h1eadf79_2.conda
+  hash:
+    md5: 40bf1b4b908b554af2f77b22fafdb0ac
+    sha256: 87724eb7e9633729f37cc2861fd984a6d1b0af6c0d984868a51fce2f96cc41a3
+  category: main
+  optional: false
 - name: scikit-learn
   version: 1.4.1.post1
   manager: conda
@@ -5632,6 +10623,25 @@ package:
   hash:
     md5: 8c27600e1ee43ba6ceff93c6c0e09446
     sha256: 1a6a130509cb4271cd40ea6a9fa7f7db85d7c83f6d914bccd20e6afbae8536ae
+  category: main
+  optional: false
+- name: scikit-learn
+  version: 1.4.1.post1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    joblib: '>=1.2.0'
+    libcxx: '>=16'
+    llvm-openmp: '>=17.0.6'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    scipy: ''
+    threadpoolctl: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.1.post1-py311he2b4599_0.conda
+  hash:
+    md5: 8283796dfe99750d19d32e17cf08ced7
+    sha256: 5e722716c645a66c281740b1af5a71d14c6878b62eabb7c8d7bce31de4ea00c2
   category: main
   optional: false
 - name: scipy
@@ -5653,6 +10663,26 @@ package:
   hash:
     md5: 24ca5107ab75c5521067b8ba505dfae5
     sha256: e5aca4c5e63314848600d6da7360e0701c512f70d1783610eed5c1f7ecf58a57
+  category: main
+  optional: false
+- name: scipy
+  version: 1.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libblas: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=15'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
+    liblapack: '>=3.9.0,<4.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.12.0-py311h86d0cd9_2.conda
+  hash:
+    md5: 9a70728fa81071937bbd1ebc3b986f44
+    sha256: 01035edbfed56239bff4b3845c0cef9b5e6a44c397c9ba131387df24ad7d36b8
   category: main
   optional: false
 - name: secretstorage
@@ -5684,10 +10714,38 @@ package:
     sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
   category: main
   optional: false
+- name: send2trash
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: ''
+    pyobjc-framework-cocoa: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  hash:
+    md5: 2657c3de5371c571aef6678afb4aaadd
+    sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  category: main
+  optional: false
 - name: sentry-sdk
   version: 1.40.5
   manager: conda
   platform: linux-64
+  dependencies:
+    certifi: ''
+    python: '>=3.7'
+    urllib3: '>=1.25.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-1.40.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: b000a35f21a027cb474cba8919537715
+    sha256: 3888c3450640dc76e7bf442ca8df339ca6c37c7bbcd7ee94372194efcfaf2ca4
+  category: main
+  optional: false
+- name: sentry-sdk
+  version: 1.40.5
+  manager: conda
+  platform: osx-64
   dependencies:
     certifi: ''
     python: '>=3.7'
@@ -5712,16 +10770,41 @@ package:
     sha256: f5c0ffdcaad92565d7041c27084a2263653d8287daf9a41c023a460d776acb72
   category: main
   optional: false
+- name: setproctitle
+  version: 1.3.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.3-py311h2725bcf_0.conda
+  hash:
+    md5: df8e28346d42b157d68efcfbe6c1d13b
+    sha256: 797e3fb314cd5b3367ab4015b0b9c48d6b928b3d34fb6736b59612ef78c3c811
+  category: main
+  optional: false
 - name: setuptools
-  version: 69.1.0
+  version: 69.1.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.1.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d76a248ad1b9d4a79c2ce39ee41d626c
-    sha256: d233a0dc17d452324a4aa1f633c18ca562820c90cd08240c99e4b2f4f27a8692
+    md5: 576de899521b7d43674ba3ef6eae9142
+    sha256: 7a6dca60efcaa42d0ebb784950bc16230a968256cb5048a4441cb34653b5ec58
+  category: main
+  optional: false
+- name: setuptools
+  version: 69.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.1.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 576de899521b7d43674ba3ef6eae9142
+    sha256: 7a6dca60efcaa42d0ebb784950bc16230a968256cb5048a4441cb34653b5ec58
   category: main
   optional: false
 - name: shapely
@@ -5740,10 +10823,37 @@ package:
     sha256: b2766384c3f79a1b71224e06608b2e7a6ba8a0da0fb4981cbc36bc929acfefc9
   category: main
   optional: false
+- name: shapely
+  version: 2.0.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    geos: '>=3.12.1,<3.12.2.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.3-py311h4c12f3d_0.conda
+  hash:
+    md5: a58eb162e082a968b0ba8ec61f1c51d0
+    sha256: 1bc3a40e9989c1a773b536223433c96c2ae975db4a2f058f4799577f0dcb4ba2
+  category: main
+  optional: false
 - name: six
   version: 1.16.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  hash:
+    md5: e5f25f8dbc060e9a8d912e432202afc2
+    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  category: main
+  optional: false
+- name: six
+  version: 1.16.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -5765,10 +10875,34 @@ package:
     sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
   category: main
   optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sleef-3.5.1-h6db0672_2.tar.bz2
+  hash:
+    md5: 16665e88f0b36693ca95dbae9b294e68
+    sha256: 6d19556f2cd022501327f65a598884a0b3ddedb1f459a4caf1d10301b247ceb6
+  category: main
+  optional: false
 - name: smmap
   version: 5.0.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: main
+  optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
@@ -5790,6 +10924,18 @@ package:
     sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
   category: main
   optional: false
+- name: snappy
+  version: 1.1.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  hash:
+    md5: 4320a8781f14cd959689b86e349f3b73
+    sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  category: main
+  optional: false
 - name: sniffio
   version: 1.3.0
   manager: conda
@@ -5802,10 +10948,34 @@ package:
     sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
   category: main
   optional: false
+- name: sniffio
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: dd6cbc539e74cb1f430efbd4575b9303
+    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  category: main
+  optional: false
 - name: snowballstemmer
   version: 2.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2'
+  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 4d22a9315e78c6827f806065957d566e
+    sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+  category: main
+  optional: false
+- name: snowballstemmer
+  version: 2.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2'
   url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
@@ -5828,6 +10998,20 @@ package:
     sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
   category: main
   optional: false
+- name: snuggs
+  version: 1.4.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: ''
+    pyparsing: '>=2.1.6'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+  hash:
+    md5: cb83a3d6ecf73f50117635192414426a
+    sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
+  category: main
+  optional: false
 - name: soupsieve
   version: '2.5'
   manager: conda
@@ -5840,53 +11024,121 @@ package:
     sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   category: main
   optional: false
+- name: soupsieve
+  version: '2.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  category: main
+  optional: false
 - name: sphinx
-  version: 5.0.2
+  version: 7.2.6
   manager: conda
   platform: linux-64
   dependencies:
     alabaster: '>=0.7,<0.8'
-    babel: '>=1.3'
-    colorama: '>=0.3.5'
-    docutils: '>=0.14,<0.19'
-    imagesize: ''
-    importlib-metadata: '>=4.4'
-    jinja2: '>=2.3'
-    packaging: ''
-    pygments: '>=2.0'
-    python: '>=3.6'
-    requests: '>=2.5.0'
-    snowballstemmer: '>=1.1'
+    babel: '>=2.9'
+    colorama: '>=0.4.5'
+    docutils: '>=0.18.1,<0.21'
+    imagesize: '>=1.3'
+    importlib-metadata: '>=4.8'
+    jinja2: '>=3.0'
+    packaging: '>=21.0'
+    pygments: '>=2.14'
+    python: '>=3.9'
+    requests: '>=2.25.0'
+    snowballstemmer: '>=2.0'
     sphinxcontrib-applehelp: ''
     sphinxcontrib-devhelp: ''
     sphinxcontrib-htmlhelp: '>=2.0.0'
     sphinxcontrib-jsmath: ''
     sphinxcontrib-qthelp: ''
-    sphinxcontrib-serializinghtml: '>=1.1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-5.0.2-pyh6c4a22f_0.tar.bz2
+    sphinxcontrib-serializinghtml: '>=1.1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: d4eaa1f50733a377480ce1d5aac556c7
-    sha256: 27fc8d942d1cedba71035399f71e2d81fd411b86c5d8717c813c46143b8d74f8
+    md5: bbfd1120d1824d2d073bc65935f0e4c0
+    sha256: 665d1fe6d20c6cc672ff20e6ebb405860f878b487d3d8d86a5952733fb7bbc42
+  category: main
+  optional: false
+- name: sphinx
+  version: 7.2.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    alabaster: '>=0.7,<0.8'
+    babel: '>=2.9'
+    colorama: '>=0.4.5'
+    docutils: '>=0.18.1,<0.21'
+    imagesize: '>=1.3'
+    importlib-metadata: '>=4.8'
+    jinja2: '>=3.0'
+    packaging: '>=21.0'
+    pygments: '>=2.14'
+    python: '>=3.9'
+    requests: '>=2.25.0'
+    snowballstemmer: '>=2.0'
+    sphinxcontrib-applehelp: ''
+    sphinxcontrib-devhelp: ''
+    sphinxcontrib-htmlhelp: '>=2.0.0'
+    sphinxcontrib-jsmath: ''
+    sphinxcontrib-qthelp: ''
+    sphinxcontrib-serializinghtml: '>=1.1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: bbfd1120d1824d2d073bc65935f0e4c0
+    sha256: 665d1fe6d20c6cc672ff20e6ebb405860f878b487d3d8d86a5952733fb7bbc42
   category: main
   optional: false
 - name: sphinx-book-theme
-  version: 1.0.1
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    pydata-sphinx-theme: '>=0.13.3'
-    python: '>=3.7'
-    sphinx: '>=4,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-book-theme-1.0.1-pyhd8ed1ab_0.conda
+    pydata-sphinx-theme: '>=0.14.0'
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-book-theme-1.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 1ef419576de2c51b6e3a5a393eb35cda
-    sha256: bbd622f59265f80a320afa7cd71d7d95b91ff009796481a7d0875b25c0d079c0
+    md5: fa675936fa91d74cc2a45fbc8df1598b
+    sha256: 0934eea9c89211f71b706bcd91c7ed3687fce1c14fcd14073231bc69f640bd53
+  category: main
+  optional: false
+- name: sphinx-book-theme
+  version: 1.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pydata-sphinx-theme: '>=0.14.0'
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-book-theme-1.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: fa675936fa91d74cc2a45fbc8df1598b
+    sha256: 0934eea9c89211f71b706bcd91c7ed3687fce1c14fcd14073231bc69f640bd53
   category: main
   optional: false
 - name: sphinx-comments
   version: 0.0.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: ''
+    sphinx: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-comments-0.0.3-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ae3ce35de0c1cec45c94182694f8d1b
+    sha256: 2578e9a84f3d4435ad1065daa55ad22a401968c09842220337e8195336f94839
+  category: main
+  optional: false
+- name: sphinx-comments
+  version: 0.0.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: ''
     sphinx: '>=1.8'
@@ -5909,46 +11161,101 @@ package:
     sha256: 7ea21f009792e7c69612ddba367afe0412b3fdff2e92f439e8cd222de4b40bfe
   category: main
   optional: false
+- name: sphinx-copybutton
+  version: 0.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3'
+    sphinx: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: ac832cc43adc79118cf6e23f1f9b8995
+    sha256: 7ea21f009792e7c69612ddba367afe0412b3fdff2e92f439e8cd222de4b40bfe
+  category: main
+  optional: false
 - name: sphinx-design
-  version: 0.3.0
+  version: 0.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    sphinx: '>=4,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+    sphinx: '>=5,<8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 83d1a712e6d2bab6b298b1d2f42ad355
-    sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
+    md5: 264b3c697fa9cdade87eb0abe4440d54
+    sha256: 5333c50f3687da5b59dd8df24094d8c0e834922ceabc1f525e54735e06d0bd52
+  category: main
+  optional: false
+- name: sphinx-design
+  version: 0.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    sphinx: '>=5,<8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 264b3c697fa9cdade87eb0abe4440d54
+    sha256: 5333c50f3687da5b59dd8df24094d8c0e834922ceabc1f525e54735e06d0bd52
   category: main
   optional: false
 - name: sphinx-external-toc
-  version: 0.3.1
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
-    click: '>=7.1,<9'
-    python: '>=3.7'
+    click: '>=7.1'
+    python: '>=3.9'
     pyyaml: ''
-    sphinx: '>=4,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-external-toc-0.3.1-pyhd8ed1ab_1.conda
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-external-toc-1.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d9a56bf4dce363e8e7e2466691668895
-    sha256: db3113a9e2077e4177880f4e9f01335ca1cfc336ac034265ecf997014c7572c5
+    md5: 7a8b55d920fa30a68a2da808abf57291
+    sha256: 1436741a948742862e69554f02b855cada81643b10c7dd632c29b1b28aa0ce96
+  category: main
+  optional: false
+- name: sphinx-external-toc
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=7.1'
+    python: '>=3.9'
+    pyyaml: ''
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-external-toc-1.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7a8b55d920fa30a68a2da808abf57291
+    sha256: 1436741a948742862e69554f02b855cada81643b10c7dd632c29b1b28aa0ce96
   category: main
   optional: false
 - name: sphinx-jupyterbook-latex
-  version: 0.5.2
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: ''
-    python: '>=3.6'
-    sphinx: '>=3,<5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-jupyterbook-latex-0.5.2-pyhd8ed1ab_0.tar.bz2
+    packaging: ''
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-jupyterbook-latex-1.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 88fc7863c8675f297b03e0ca50500b7f
-    sha256: d1f1ccb786934955b500a8006ab84db075d34b8be66571dccf4e270109db433f
+    md5: 90b6071fb02e56a1aafc85e52721fa0e
+    sha256: 648307f83e8843b9685a6d979e6bffd7cb0a0d6b81d62b64cbd7c843f87abeb6
+  category: main
+  optional: false
+- name: sphinx-jupyterbook-latex
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-jupyterbook-latex-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 90b6071fb02e56a1aafc85e52721fa0e
+    sha256: 648307f83e8843b9685a6d979e6bffd7cb0a0d6b81d62b64cbd7c843f87abeb6
   category: main
   optional: false
 - name: sphinx-multitoc-numbering
@@ -5964,23 +11271,63 @@ package:
     sha256: 6c8241fdb4222799c04677b06b2e1f480a6c11f27c8fccc9f73f98798d3c44d8
   category: main
   optional: false
+- name: sphinx-multitoc-numbering
+  version: 0.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+    sphinx: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-multitoc-numbering-0.1.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 40749a4d0f0d2e11c65fb26c1cd16a90
+    sha256: 6c8241fdb4222799c04677b06b2e1f480a6c11f27c8fccc9f73f98798d3c44d8
+  category: main
+  optional: false
 - name: sphinx-thebe
-  version: 0.2.1
+  version: 0.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    sphinx: '>=4,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-thebe-0.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    sphinx: '>=4'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-thebe-0.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8a4151bde2af98c6cbc42ee12b48eb7f
-    sha256: 4b083e89ec6ee314e4971dbb442d5ea5d54539629090eb90e5688ec0648afabd
+    md5: c7895f70474a3883c9ff75c290dff551
+    sha256: a6c9c15b59edcf957cc6e6122269c07164a08d71754852f65819375844fd843d
+  category: main
+  optional: false
+- name: sphinx-thebe
+  version: 0.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+    sphinx: '>=4'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-thebe-0.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c7895f70474a3883c9ff75c290dff551
+    sha256: a6c9c15b59edcf957cc6e6122269c07164a08d71754852f65819375844fd843d
   category: main
   optional: false
 - name: sphinx-togglebutton
   version: 0.3.2
   manager: conda
   platform: linux-64
+  dependencies:
+    docutils: ''
+    python: '>=3.6'
+    sphinx: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-togglebutton-0.3.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 382738101934261ea7931d1460e64868
+    sha256: 0dcee238aae6337fae5eaf1f9a29b0c51ed9834ae501fccb2cde0fed8dae1a88
+  category: main
+  optional: false
+- name: sphinx-togglebutton
+  version: 0.3.2
+  manager: conda
+  platform: osx-64
   dependencies:
     docutils: ''
     python: '>=3.6'
@@ -6004,28 +11351,72 @@ package:
     sha256: 710013443a063518d587d2af82299e92ab6d6695edf35a676ac3a0ccc9e3f8e6
   category: main
   optional: false
+- name: sphinxcontrib-applehelp
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 611a35a27914fac3aa37611a6fe40bb5
+    sha256: 710013443a063518d587d2af82299e92ab6d6695edf35a676ac3a0ccc9e3f8e6
+  category: main
+  optional: false
 - name: sphinxcontrib-bibtex
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: linux-64
   dependencies:
     dataclasses: ''
-    docutils: '>=0.8'
+    docutils: '>=0.8,!=0.18.*,!=0.19.*'
     importlib_metadata: '>=3.6'
     pybtex: '>=0.24'
-    pybtex-docutils: '>=1'
-    python: '>=3.6'
-    sphinx: '>=2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.5.0-pyhd8ed1ab_0.tar.bz2
+    pybtex-docutils: '>=1.0.0'
+    python: '>=3.7'
+    sphinx: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b2e5c9aece936ebf9f26abdf71ddd74b
-    sha256: d5b02d285909b4501a469857b1a88a91a849d5f28bbe64b9e6c3e86d2388d345
+    md5: ac0947374ec8b703181808828bf5dfec
+    sha256: 67de4b2e9a50d9ee38914aca6faebd44f31b0821a43517b0a805afc889372311
+  category: main
+  optional: false
+- name: sphinxcontrib-bibtex
+  version: 2.6.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    dataclasses: ''
+    docutils: '>=0.8,!=0.18.*,!=0.19.*'
+    importlib_metadata: '>=3.6'
+    pybtex: '>=0.24'
+    pybtex-docutils: '>=1.0.0'
+    python: '>=3.7'
+    sphinx: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: ac0947374ec8b703181808828bf5dfec
+    sha256: 67de4b2e9a50d9ee38914aca6faebd44f31b0821a43517b0a805afc889372311
   category: main
   optional: false
 - name: sphinxcontrib-devhelp
   version: 1.0.6
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: d7e4954df0d3aea2eacc7835ad12671d
+    sha256: 63a6b60653ef13a6712848f4b3c4b713d4b564da1dae571893f1a3659cde85f3
+  category: main
+  optional: false
+- name: sphinxcontrib-devhelp
+  version: 1.0.6
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
@@ -6048,10 +11439,35 @@ package:
     sha256: 512f393cfe34cb3de96ade7a7ad900d6278e2087a1f0e5732aa60fadee396d99
   category: main
   optional: false
+- name: sphinxcontrib-htmlhelp
+  version: 2.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7e1e7437273682ada2ed5e9e9714b140
+    sha256: 512f393cfe34cb3de96ade7a7ad900d6278e2087a1f0e5732aa60fadee396d99
+  category: main
+  optional: false
 - name: sphinxcontrib-jsmath
   version: 1.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: da1d979339e2714c30a8e806a33ec087
+    sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
+  category: main
+  optional: false
+- name: sphinxcontrib-jsmath
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
@@ -6073,10 +11489,36 @@ package:
     sha256: dd35b52f056c39081cd0ae01155174277af579b69e5d83798a33e9056ec78d63
   category: main
   optional: false
+- name: sphinxcontrib-qthelp
+  version: 1.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 26acae54b06f178681bfb551760f5dd1
+    sha256: dd35b52f056c39081cd0ae01155174277af579b69e5d83798a33e9056ec78d63
+  category: main
+  optional: false
 - name: sphinxcontrib-serializinghtml
   version: 1.1.10
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    sphinx: '>=5'
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
+  hash:
+    md5: e507335cb4ca9cff4c3d0fa9cdab255e
+    sha256: bf80e4c0ff97d5e8e5f6db0831ba60007e820a3a438e8f1afd868aa516d67d6f
+  category: main
+  optional: false
+- name: sphinxcontrib-serializinghtml
+  version: 1.1.10
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
@@ -6102,6 +11544,21 @@ package:
     sha256: 6c87ba0e5c05c3f9f67e214de4f9b4420159f59756cc5b4141f8e8b2dfce60d4
   category: main
   optional: false
+- name: sqlalchemy
+  version: 2.0.27
+  manager: conda
+  platform: osx-64
+  dependencies:
+    greenlet: '!=0.4.17'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-2.0.27-py311he705e18_0.conda
+  hash:
+    md5: 7925692e0bf9b67432e8f507025ab961
+    sha256: bdb75e8c4fa8508800ea5084a4a21ad076684e9529db06d2d1efd731a3892d72
+  category: main
+  optional: false
 - name: sqlite
   version: 3.45.1
   manager: conda
@@ -6118,10 +11575,40 @@ package:
     sha256: a7cbde68eff5d2ec9bb1b5f2604a523949048a9b5335588eac2d893fd0dd5200
   category: main
   optional: false
+- name: sqlite
+  version: 3.45.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libsqlite: 3.45.1
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    readline: '>=8.2,<9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.1-h7461747_0.conda
+  hash:
+    md5: 239ff6ffc3ee45898db19e3cbbf40f88
+    sha256: ce0908a02a1965854dde0022f5ba9b986324077ba4835a3c990463ed762e6e8f
+  category: main
+  optional: false
 - name: stack_data
   version: 0.6.2
   manager: conda
   platform: linux-64
+  dependencies:
+    asttokens: ''
+    executing: ''
+    pure_eval: ''
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: e7df0fdd404616638df5ece6e69ba7af
+    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  category: main
+  optional: false
+- name: stack_data
+  version: 0.6.2
+  manager: conda
+  platform: osx-64
   dependencies:
     asttokens: ''
     executing: ''
@@ -6149,6 +11636,22 @@ package:
     sha256: 1baf4cb93fd7603176c28521d9d8bde25f3d9029f2a8a170a9b083c47931ca2d
   category: main
   optional: false
+- name: stackstac
+  version: 0.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    dask-core: '>=2022.1.1'
+    pyproj: <4.0.0,>=3.0.0
+    python: '>=3.8,<4.0'
+    rasterio: <2.0.0,>=1.3.0
+    xarray: '>=0.18'
+  url: https://conda.anaconda.org/conda-forge/noarch/stackstac-0.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a1295d17c40cb4ec767e396293a44d98
+    sha256: 1baf4cb93fd7603176c28521d9d8bde25f3d9029f2a8a170a9b083c47931ca2d
+  category: main
+  optional: false
 - name: svt-av1
   version: 1.8.0
   manager: conda
@@ -6162,10 +11665,38 @@ package:
     sha256: 6d64facdcdaadc5a3e5e4382ee195b4fde3c84ae3d4156fdd9b78ba7de358ba7
   category: main
   optional: false
+- name: svt-av1
+  version: 1.8.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
+  hash:
+    md5: 5cfb5476c2e9308c77afe3427da3b3b3
+    sha256: ce33415f2ffd1643e26a3e464c416a96b68e409f985021f5314efe4f402a8c09
+  category: main
+  optional: false
 - name: sympy
   version: '1.12'
   manager: conda
   platform: linux-64
+  dependencies:
+    __unix: ''
+    gmpy2: '>=2.0.8'
+    mpmath: '>=0.19'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
+  hash:
+    md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
+    sha256: 0025dd4e6411423903bf478d1b9fbff0cbbbe546f51c9375dfd6729ef2e1a1ac
+  category: main
+  optional: false
+- name: sympy
+  version: '1.12'
+  manager: conda
+  platform: osx-64
   dependencies:
     __unix: ''
     gmpy2: '>=2.0.8'
@@ -6189,6 +11720,18 @@ package:
     sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
   category: main
   optional: false
+- name: tabulate
+  version: 0.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: 4759805cce2d914c38472f70bf4d8bcb
+    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  category: main
+  optional: false
 - name: tbb
   version: 2021.11.0
   manager: conda
@@ -6201,6 +11744,19 @@ package:
   hash:
     md5: 4531d2927578e7e254ff3bcf6457518c
     sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
+  category: main
+  optional: false
+- name: tbb
+  version: 2021.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    libhwloc: '>=2.9.3,<2.9.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+  hash:
+    md5: 29e29beba9deb0ef66bee015c5bf3c14
+    sha256: 6d531daba5ccf150b58d434fa72b1da0da04e8f14ab71bdad289a90d355f47e8
   category: main
   optional: false
 - name: terminado
@@ -6218,6 +11774,21 @@ package:
     sha256: e90139ef15ea9d75a69cd6b6302c29ed5b01c03ddfa717b71acb32b60af74269
   category: main
   optional: false
+- name: terminado
+  version: 0.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: ''
+    ptyprocess: ''
+    python: '>=3.8'
+    tornado: '>=6.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh31c8845_0.conda
+  hash:
+    md5: 14759b57f5b9d97033e633fff0a2d27e
+    sha256: 8e8741c688ade9be8f86c0b209780c7fbe4a97e4265311ca9d8dda5fcedc6a28
+  category: main
+  optional: false
 - name: threadpoolctl
   version: 3.3.0
   manager: conda
@@ -6230,10 +11801,36 @@ package:
     sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
   category: main
   optional: false
+- name: threadpoolctl
+  version: 3.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  hash:
+    md5: 698d2d2b621640bddb9191f132967c9f
+    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+  category: main
+  optional: false
 - name: tifffile
   version: 2024.2.12
   manager: conda
   platform: linux-64
+  dependencies:
+    imagecodecs: '>=2023.8.12'
+    numpy: '>=1.19.2'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.2.12-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5c8bef52be4e70c48b1400eec3eecc8
+    sha256: 5b629ab2eae0508ad554cc831fed72950d74909d6bcf2aebdfd01e0c0afca60b
+  category: main
+  optional: false
+- name: tifffile
+  version: 2024.2.12
+  manager: conda
+  platform: osx-64
   dependencies:
     imagecodecs: '>=2023.8.12'
     numpy: '>=1.19.2'
@@ -6269,10 +11866,48 @@ package:
     sha256: abc460ddf0205dfbeb987678ca882fedcf152d91fbfe7acba2a46c10a306d9cd
   category: main
   optional: false
+- name: tiledb
+  version: 2.20.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.10.3,<1.11.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<13.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libxml2: '>=2.12.5,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.20.0-h8fd0293_0.conda
+  hash:
+    md5: 6585a0f5ff3f277826a392e1a5ab0ee6
+    sha256: 6d1d383dcd6722f99ce26d4e042eb1ea69da4d62256f29b9318d3849d56a359c
+  category: main
+  optional: false
 - name: tinycss2
   version: 1.2.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 7234c9eefff659501cd2fe0d2ede4d48
+    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  category: main
+  optional: false
+- name: tinycss2
+  version: 1.2.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.5'
     webencodings: '>=0.4'
@@ -6295,6 +11930,18 @@ package:
     sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
   category: main
   optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  hash:
+    md5: bf830ba5afc507c6232d4ef0fb1a882d
+    sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  category: main
+  optional: false
 - name: tokenizers
   version: 0.14.1
   manager: conda
@@ -6312,10 +11959,38 @@ package:
     sha256: 7d9338ccc698685307d87dcadfdf6c30e0795cd8fa6e55be16c9e4822aa0eba6
   category: main
   optional: false
+- name: tokenizers
+  version: 0.14.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    huggingface_hub: '>=0.16.4,<0.18'
+    libcxx: '>=16.0.6'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/tokenizers-0.14.1-py311h4b661d2_2.conda
+  hash:
+    md5: 82d2243fade5110374d5fb9b1130e1d0
+    sha256: 028cfde4ad6e71631f1cebf498b8c6b88ce4eea28fc4d240bd3225f209258b25
+  category: main
+  optional: false
 - name: tomli
   version: 2.0.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  category: main
+  optional: false
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
@@ -6336,10 +12011,34 @@ package:
     sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
   category: main
   optional: false
+- name: tomlkit
+  version: 0.12.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.3-pyha770c72_0.conda
+  hash:
+    md5: 074d0ce7a6261ab8b497c3518796ef3e
+    sha256: 53cc436ab92d38683df1320e4468a8b978428e800195bf1c8c2460e90b0bc117
+  category: main
+  optional: false
 - name: toolz
   version: 0.12.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2fcb582444635e2c402e8569bb94e039
+    sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
+  category: main
+  optional: false
+- name: toolz
+  version: 0.12.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
@@ -6367,10 +12066,45 @@ package:
     sha256: d52efdb064a8aa345c4146f590a0a94ca918b36dae5b26a57ff78dfc60d18bff
   category: main
   optional: false
+- name: torchdata
+  version: 0.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-sdk-cpp: '>=1.11.210,<1.11.211.0a0'
+    libcxx: '>=15'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    pytorch: '>=2.1.0,<2.2.0a0'
+    requests: ''
+    urllib3: '>=1.25'
+  url: https://conda.anaconda.org/conda-forge/osx-64/torchdata-0.7.1-py311h13cd078_1.conda
+  hash:
+    md5: e4fe4263db17300a902c6f02d600d38e
+    sha256: 93b974c5ee547866e60e5f5fb6a597713c0caa6780564a4b61f9d7872c15a0fe
+  category: main
+  optional: false
 - name: torchmetrics
   version: 1.2.1
   manager: conda
   platform: linux-64
+  dependencies:
+    lightning-utilities: '>=0.8.0'
+    numpy: '>1.20.0'
+    packaging: '>17.1'
+    python: '>=3.7'
+    pytorch: '>=1.8.1'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: f6468e9ea893241ad7b8eae519f7e3a5
+    sha256: 26abe526d9514f096f196628ede28fb10d8e65cc19350b3be19f7bc465a22cec
+  category: main
+  optional: false
+- name: torchmetrics
+  version: 1.2.1
+  manager: conda
+  platform: osx-64
   dependencies:
     lightning-utilities: '>=0.8.0'
     numpy: '>1.20.0'
@@ -6411,6 +12145,26 @@ package:
     sha256: 57c294734e67b616f308c1dea1ab825bf9ca01f7ea97502f3fb5bd5a2a63ad0b
   category: main
   optional: false
+- name: torchvision
+  version: 0.16.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    numpy: '>=1.23.5,<2.0a0'
+    pillow: '>=5.3.0,!=8.3.0,!=8.3.1'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    pytorch: '>=2.1.0,<2.2.0a0'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/torchvision-0.16.1-cpu_py311hd11fb1e_2.conda
+  hash:
+    md5: 755821ed74aa62506f864747893efc7d
+    sha256: 16e60616f3d854e278910d92b9287df775c37ca8b9270cf9677390161ef996c8
+  category: main
+  optional: false
 - name: tornado
   version: '6.4'
   manager: conda
@@ -6423,6 +12177,19 @@ package:
   hash:
     md5: cc7727006191b8f3630936b339a76cd0
     sha256: 5bb1e24d1767e403183e4cc842d184b2da497e778f0311c5b1d023fb3af9e6b6
+  category: main
+  optional: false
+- name: tornado
+  version: '6.4'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4-py311he705e18_0.conda
+  hash:
+    md5: 40845aadca8df7ccc21c393ba3aa9eac
+    sha256: 0b994ce7984953d1d528b7e19a97db0b34da09398feaf592500df637719d5623
   category: main
   optional: false
 - name: tqdm
@@ -6438,10 +12205,35 @@ package:
     sha256: 416d1d9318f3267325ad7e2b8a575df20ff9031197b30c0222c3d3b023877260
   category: main
   optional: false
+- name: tqdm
+  version: 4.66.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    colorama: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2b8dfb969f984497f3f98409a9545776
+    sha256: 416d1d9318f3267325ad7e2b8a575df20ff9031197b30c0222c3d3b023877260
+  category: main
+  optional: false
 - name: traitlets
   version: 5.14.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1c6acfdc7ecbfe09954c4216da99c146
+    sha256: fa78d68f74ec8aae5c93f135140bfdbbf0ab60a79c6062b55d73c316068545ec
+  category: main
+  optional: false
+- name: traitlets
+  version: 5.14.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
@@ -6476,10 +12268,48 @@ package:
     sha256: 66304ccc2b1fa849e06b3b5433c4ec54709f011e0dde1271ee97153b60c94424
   category: main
   optional: false
+- name: transformers
+  version: 4.35.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    dataclasses: ''
+    datasets: '!=2.5.0'
+    filelock: ''
+    huggingface_hub: ''
+    importlib_metadata: ''
+    numpy: '>=1.17'
+    packaging: '>=20.0'
+    python: '>=3.7'
+    pyyaml: ''
+    regex: '!=2019.12.17'
+    requests: ''
+    sacremoses: ''
+    safetensors: '>=0.3.1'
+    tokenizers: '>=0.14,<0.15'
+    tqdm: '>=4.27'
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.35.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: eac12c11dc229eed493e680907557d10
+    sha256: 66304ccc2b1fa849e06b3b5433c4ec54709f011e0dde1271ee97153b60c94424
+  category: main
+  optional: false
 - name: types-python-dateutil
   version: 2.8.19.20240106
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
+  hash:
+    md5: c9096a546660b9079dce531c0039e074
+    sha256: 09ef8cc587bdea80a83b6f820dbae24daadcf82be088fb0a9f6495781653e300
+  category: main
+  optional: false
+- name: types-python-dateutil
+  version: 2.8.19.20240106
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
@@ -6501,10 +12331,35 @@ package:
     sha256: 75667335c7bddc9148701fbb1e9aeaba07ab310f1694746ce6f3baee34637ef5
   category: main
   optional: false
+- name: typeshed-client
+  version: 2.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-resources: '>=1.4.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/typeshed-client-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 32af6c9899b46001b90df3bb2db1e896
+    sha256: 75667335c7bddc9148701fbb1e9aeaba07ab310f1694746ce6f3baee34637ef5
+  category: main
+  optional: false
 - name: typing-extensions
   version: 4.9.0
   manager: conda
   platform: linux-64
+  dependencies:
+    typing_extensions: 4.9.0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
+  hash:
+    md5: c16524c1b7227dc80b36b4fa6f77cc86
+    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
+  category: main
+  optional: false
+- name: typing-extensions
+  version: 4.9.0
+  manager: conda
+  platform: osx-64
   dependencies:
     typing_extensions: 4.9.0
   url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
@@ -6525,10 +12380,34 @@ package:
     sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
   category: main
   optional: false
+- name: typing_extensions
+  version: 4.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
+  hash:
+    md5: a92a6440c3fe7052d63244f3aba2a4a7
+    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
+  category: main
+  optional: false
 - name: typing_utils
   version: 0.1.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: eb67e3cace64c66233e2d35949e20f92
+    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  category: main
+  optional: false
+- name: typing_utils
+  version: 0.1.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
@@ -6550,6 +12429,17 @@ package:
     sha256: d3ea2927cabd6c9f27ee0cb498f893ac0133687d6a9e65e0bce4861c732a18df
   category: main
   optional: false
+- name: tzcode
+  version: 2024a
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
+  hash:
+    md5: 8d50ba6668dbd193cd42ccd9099fa2ae
+    sha256: e3ee34b2711500f3b1d38309d47cfd7e4d05c0144f0b2b2bdfbc271a28cfdd76
+  category: main
+  optional: false
 - name: tzdata
   version: 2024a
   manager: conda
@@ -6561,10 +12451,33 @@ package:
     sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
   category: main
   optional: false
+- name: tzdata
+  version: 2024a
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  hash:
+    md5: 161081fc7cec0bfda0d86d7cb595f8d8
+    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  category: main
+  optional: false
 - name: uc-micro-py
   version: 1.0.3
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3b7fc78d7be7b450952aaa916fb78877
+    sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  category: main
+  optional: false
+- name: uc-micro-py
+  version: 1.0.3
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
@@ -6601,6 +12514,18 @@ package:
     sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   category: main
   optional: false
+- name: uri-template
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  category: main
+  optional: false
 - name: uriparser
   version: 0.9.7
   manager: conda
@@ -6612,6 +12537,18 @@ package:
   hash:
     md5: 2c46deb08ba9b10e90d0a6401ad65deb
     sha256: bc7670384fc3e519b376eab25b2c747afe392b243f17e881075231f4a0f2e5a0
+  category: main
+  optional: false
+- name: uriparser
+  version: 0.9.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-hf0c8a7f_1.conda
+  hash:
+    md5: 998073b0ccb5f99d07d2089cf06363b3
+    sha256: faf0f7919851960bbb1d18d977f62082c0e4dc8f26e348d702e8a2dba53a4c37
   category: main
   optional: false
 - name: urllib3
@@ -6628,10 +12565,36 @@ package:
     sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
   category: main
   optional: false
+- name: urllib3
+  version: 1.26.18
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  hash:
+    md5: bf61cfd2a7f212efba378167a07d4a6a
+    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+  category: main
+  optional: false
 - name: validators
   version: 0.22.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/validators-0.22.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 56435633ef70e7b92c54151599cbf757
+    sha256: f30699fd1a76cf3291e042167f8dc8dd28e00e08e49047a353304c7ad7bc279d
+  category: main
+  optional: false
+- name: validators
+  version: 0.22.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/validators-0.22.0-pyhd8ed1ab_0.conda
@@ -6655,10 +12618,40 @@ package:
     sha256: 1ced4445cf72cd9dc344ad04bdaf703a08cc428c8c46e4bda928ad79786ee153
   category: main
   optional: false
+- name: virtualenv
+  version: 20.25.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    distlib: <1,>=0.3.7
+    filelock: <4,>=3.12.2
+    platformdirs: <5,>=3.9.1
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8797a4e26be36880a603aba29c785352
+    sha256: 1ced4445cf72cd9dc344ad04bdaf703a08cc428c8c46e4bda928ad79786ee153
+  category: main
+  optional: false
 - name: vit-pytorch
   version: 1.6.5
   manager: conda
   platform: linux-64
+  dependencies:
+    einops: '>=0.7.0'
+    python: '>=3.6'
+    pytorch: '>=1.10'
+    torchvision: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/vit-pytorch-1.6.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2aadadb9111d4e01d30deaba3a130941
+    sha256: 0b90dcfe6d73814d422a6acb603b8c35c73116877797ea2a6a3d4045bf9fc09d
+  category: main
+  optional: false
+- name: vit-pytorch
+  version: 1.6.5
+  manager: conda
+  platform: osx-64
   dependencies:
     einops: '>=0.7.0'
     python: '>=3.6'
@@ -6695,10 +12688,47 @@ package:
     sha256: c2f10522299816dc4d39f6aa7346651ae4eeac2140745619dd318451bcd2b91b
   category: main
   optional: false
+- name: wandb
+  version: 0.15.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    appdirs: '>=1.4.3'
+    click: '>=7.1,!=8.0.0'
+    docker-pycreds: '>=0.4.0'
+    gitpython: '>=1.0.0,!=3.1.29'
+    pathtools: ''
+    protobuf: '>=3.19.0,!=4.21.0,<5'
+    psutil: '>=5.0.0'
+    python: '>=3.7'
+    pyyaml: ''
+    requests: '>=2.0.0,<3'
+    sentry-sdk: '>=1.0.0'
+    setproctitle: ''
+    setuptools: ''
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/wandb-0.15.12-pyhd8ed1ab_0.conda
+  hash:
+    md5: fa93cd3b1f3311ddd07df0a393e18c19
+    sha256: c2f10522299816dc4d39f6aa7346651ae4eeac2140745619dd318451bcd2b91b
+  category: main
+  optional: false
 - name: wcwidth
   version: 0.2.13
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 68f0738df502a14213624b288c60c9ad
+    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  category: main
+  optional: false
+- name: wcwidth
+  version: 0.2.13
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
@@ -6719,10 +12749,34 @@ package:
     sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   category: main
   optional: false
+- name: webcolors
+  version: '1.13'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  category: main
+  optional: false
 - name: webencodings
   version: 0.5.1
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  category: main
+  optional: false
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=2.6'
   url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
@@ -6743,10 +12797,37 @@ package:
     sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
   category: main
   optional: false
+- name: websocket-client
+  version: 1.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 50ad31e07d706aae88b14a4ac9c73f23
+    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
+  category: main
+  optional: false
 - name: xarray
   version: 2024.2.0
   manager: conda
   platform: linux-64
+  dependencies:
+    numpy: '>=1.23'
+    packaging: '>=22'
+    pandas: '>=1.5'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8e25aab3323476d4fd0b5f6bad05d403
+    sha256: 4b0a8143f5c501246214823fe543e9d0749c950fdbdd39de6d8cd6209da2259f
+  category: main
+  optional: false
+- name: xarray
+  version: 2024.2.0
+  manager: conda
+  platform: osx-64
   dependencies:
     numpy: '>=1.23'
     packaging: '>=22'
@@ -6772,6 +12853,20 @@ package:
   hash:
     md5: 63b80ca78d29380fe69e69412dcbe4ac
     sha256: 75d06ca406f03f653d7a3183f2a1ccfdb3a3c6c830493933ec4c3c98e06a32bb
+  category: main
+  optional: false
+- name: xerces-c
+  version: 3.2.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+  hash:
+    md5: ade166000a13c81d9a75f65281e302b0
+    sha256: 10487c0b28ee2303570c6d0867000587a8c36836fffd4d634d8778c494d16965
   category: main
   optional: false
 - name: xorg-kbproto
@@ -6840,6 +12935,17 @@ package:
     sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
   category: main
   optional: false
+- name: xorg-libxau
+  version: 1.0.11
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  hash:
+    md5: 9566b4c29274125b0266d0177b5eb97b
+    sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  category: main
+  optional: false
 - name: xorg-libxdmcp
   version: 1.1.3
   manager: conda
@@ -6850,6 +12956,17 @@ package:
   hash:
     md5: be93aabceefa2fac576e971aef407908
     sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  category: main
+  optional: false
+- name: xorg-libxdmcp
+  version: 1.1.3
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  hash:
+    md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+    sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
   category: main
   optional: false
 - name: xorg-libxext
@@ -6928,6 +13045,17 @@ package:
     sha256: 6fe74a8fd84ab0dc25e4dc3e0c22388dd8accb212897a208b14fe5d4fbb8fc2f
   category: main
   optional: false
+- name: xxhash
+  version: 0.8.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xxhash-0.8.2-h4140336_0.conda
+  hash:
+    md5: 7e1dd1923f44ab000be63d9e40ed9ed7
+    sha256: 2a4bbe7965b99d405ddafcd05434425d8d57b34982c590eb8036eb870d8d8b86
+  category: main
+  optional: false
 - name: xz
   version: 5.2.6
   manager: conda
@@ -6940,6 +13068,17 @@ package:
     sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   category: main
   optional: false
+- name: xz
+  version: 5.2.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  hash:
+    md5: a72f9d4ea13d55d745ff1ed594747f10
+    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  category: main
+  optional: false
 - name: yaml
   version: 0.2.5
   manager: conda
@@ -6950,6 +13089,17 @@ package:
   hash:
     md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
     sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  category: main
+  optional: false
+- name: yaml
+  version: 0.2.5
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  hash:
+    md5: d7e08fcf8259d742156188e8762b4d20
+    sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
   category: main
   optional: false
 - name: yarl
@@ -6968,10 +13118,41 @@ package:
     sha256: 673e4a626e9e7d661154e5609f696c0c8a9247087f5c8b7744cfbb4fe0872713
   category: main
   optional: false
+- name: yarl
+  version: 1.9.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    idna: '>=2.0'
+    multidict: '>=4.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.4-py311he705e18_0.conda
+  hash:
+    md5: 6b7f34fc151c338cdaca4d4d6fb92d55
+    sha256: 668ea9d1e0c7b4eaa769cc79de1ea4e8da22a61d4112e660ecbaca140f097109
+  category: main
+  optional: false
 - name: zarr
   version: 2.16.1
   manager: conda
   platform: linux-64
+  dependencies:
+    asciitree: ''
+    fasteners: ''
+    numcodecs: '>=0.10.0'
+    numpy: '>=1.20,!=1.21.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 59ec835edbee50266b7bdbadab7ba335
+    sha256: a320989af085d1700ace9d982e6fdb7a63de11331ab7f8bf4cf4f636e3962b65
+  category: main
+  optional: false
+- name: zarr
+  version: 2.16.1
+  manager: conda
+  platform: osx-64
   dependencies:
     asciitree: ''
     fasteners: ''
@@ -6998,6 +13179,20 @@ package:
     sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
   category: main
   optional: false
+- name: zeromq
+  version: 4.3.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    libcxx: '>=16.0.6'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+  hash:
+    md5: 4c055e46b394be36681fe476c1e2ee6e
+    sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
+  category: main
+  optional: false
 - name: zfp
   version: 1.0.1
   manager: conda
@@ -7012,10 +13207,35 @@ package:
     sha256: 52c3bb8ab48892a2851e84764b0d35589434aebebe7941d44d9aeffde53c26d3
   category: main
   optional: false
+- name: zfp
+  version: 1.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=15'
+    llvm-openmp: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zfp-1.0.1-h295e98d_0.conda
+  hash:
+    md5: 24914bd3df9683b6f3971f7aa4844920
+    sha256: 762661fd097fa03d64e816870d9d46fa4aaafa4a502ce0fdccf2eae9d167898c
+  category: main
+  optional: false
 - name: zipp
   version: 3.17.0
   manager: conda
   platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  category: main
+  optional: false
+- name: zipp
+  version: 3.17.0
+  manager: conda
+  platform: osx-64
   dependencies:
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
@@ -7037,6 +13257,18 @@ package:
     sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
   category: main
   optional: false
+- name: zlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: 1.2.13
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 75a8a98b1c4671c5d2897975731da42d
+    sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  category: main
+  optional: false
 - name: zlib-ng
   version: 2.0.7
   manager: conda
@@ -7047,6 +13279,17 @@ package:
   hash:
     md5: 49e8329110001f04923fe7e864990b0c
     sha256: 6b3a22b7cc219e8d83f16c1ceba67aa51e0b7e3bcc4a647b97a0a510559b0477
+  category: main
+  optional: false
+- name: zlib-ng
+  version: 2.0.7
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.0.7-hb7f2c08_0.conda
+  hash:
+    md5: 813b5ad3ba92b75b84f40602b6d34ffb
+    sha256: 701bf17f3e22c7ba24ca547ccf4b2b5b4b58eda579ddaf68c0571427b10aa366
   category: main
   optional: false
 - name: zstd
@@ -7061,5 +13304,17 @@ package:
   hash:
     md5: 04b88013080254850d6c01ed54810589
     sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  hash:
+    md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+    sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
   category: main
   optional: false

--- a/environment.yml
+++ b/environment.yml
@@ -8,14 +8,15 @@ dependencies:
   - fiona~=1.9.5
   - geopandas-base~=0.14.1
   - h5netcdf~=1.3.0
-  - jupyter-book~=0.15.1
+  - jupyter-book~=1.0.0
   - jupyterlab~=4.0.7
   - jsonargparse~=4.27.0
   - lightning~=2.1.0
   - matplotlib-base~=3.8.2
   - planetary-computer~=1.0.0
-  - pytorch~=2.1.0=*cuda120*
-  - python=3.11
+  - pytorch~=2.1.0  # [osx]
+  - pytorch~=2.1.0 *cuda12*  # [linux]
+  - python~=3.11.0
   - rioxarray~=0.15.0
   - scikit-image~=0.22.0
   - scikit-learn~=1.4.0
@@ -26,3 +27,6 @@ dependencies:
   - vit-pytorch~=1.6.4
   - wandb~=0.15.12
   - zarr~=2.16.1
+platforms:
+  - linux-64
+  - osx-64


### PR DESCRIPTION
Addresses https://github.com/Clay-foundation/model/issues/161 regarding OSX/CUDA incompatability. Also adds macos-12 to os matrix in GitHub CI workflow.