### PR TITLE
Add a docker container (and docker-compose file) to run the model/notebooks in a containerize environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# FROM condaforge/miniforge3:latest
+
+# WORKDIR /model
+
+# COPY . .
+
+# RUN mamba install -y -n base --file environment.yml
+
+# #RUN mamba activate claymodel
+# #RUN echo "mamba activate ${ENV_NAME}" >> ~/.bash_profile
+
+# ENTRYPOINT [ "bash", "-l", "-c" ]
+
+# CMD ["jupyter-lab", "--ip", "0.0.0.0", "--port", "8888", "--allow-root"]
+
+FROM mambaorg/micromamba:1.5.6 
+
+WORKDIR /model
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER . .
+
+RUN micromamba create -y -n claymodel --file environment.yml && \
+    micromamba clean --all --yes
+
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
+CMD ["jupyter-lab", "--ip", "0.0.0.0", "--port", "8888", "--allow-root"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  claymodel:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+      args: 
+        - platform=linux/amd64 # Specify the target platform for build
+    platform: linux/amd64 # Specify the target platform for run
+    ports:
+      - "8888:8888" # Expose port 8888 on the host and bind it to port 8888 in the container
+    volumes:
+      - .:/model # Mount the current directory to /app in the container
+    environment:
+      - ENV_NAME=claymodel # Ensure the claymodel conda environment is activated

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,8 @@ dependencies:
   - lightning~=2.1.0
   - matplotlib-base~=3.8.2
   - planetary-computer~=1.0.0
-  - pytorch~=2.1.0=*cuda120*
+  - pytorch~=2.1.0
+  - pyarrow~=15.0.0
   - python=3.11
   - rioxarray~=0.15.0
   - scikit-image~=0.22.0
@@ -26,3 +27,4 @@ dependencies:
   - vit-pytorch~=1.6.4
   - wandb~=0.15.12
   - zarr~=2.16.1
+  


### PR DESCRIPTION
In order to make it easier to run the model/notebooks without having to manage installing dependencies across various machines/environments, I've added a `micromamba` based Dockerfile which will create the conda environment with the specified libraries. 

I've also added a docker compose file, in order to specify the build-time and run-time arguments for exposing the jupyter lab port and mounting the current directly as a volume, into the docker container. This will allow users to modify any of the model/notebook code locally, without having to re-build the image. 

By default the docker image starts with running jupyter lab but this can be overridden both in the docker-compose or even in the command line with any other python or bash command. 

The `platform=linux/amd64` build and run-time args enable the image to be built on Mac M1 while maintaining compatibility with Linux. 

The container can be run with: 
`docker-compose up` or `docker-compose run claymodel <command>` where `command` is a command which override the jupyter lab startup

The container can also be built directly (bypassing the need for docker-compose) with: 
```bash
docker build . -t clay --platform linux/amd64
```
and then run with: 
```bash
docker run --rm -it -v $(pwd):/model -p 8888:8888 -e ENV_NAME=claymodel --platform linux/amd64 clay:latest
```