### PR TITLE
Tutorial notebook for Digital Earth Pacific use case

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -44,6 +44,8 @@ parts:
       file: clay-v0-interpolation
     - title: Generate embeddings from partial inputs
       file: partial-inputs
+    - title: Digital Earth Pacific
+      file: tutorial_digital_earth_pacific
 - caption: About Clay
   chapters:
     - title: GitHub

--- a/docs/tutorial_digital_earth_pacific.ipynb
+++ b/docs/tutorial_digital_earth_pacific.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "287c93e9",
+   "metadata": {},
+   "source": [
+    "# Digital Earth Pacific mineral resource detection using Clay\n",
+    "\n",
+    "This notebook applies the Clay model on imagery composites, specifically a Sentinel-2\n",
+    "Geometric Median [(GeoMAD)](https://docs.digitalearthafrica.org/en/latest/data_specs/GeoMAD_specs.html)\n",
+    "and Sentinel-1 mean composite. We will use\n",
+    "[Digital Earth Pacific's STAC API](https://stac-browser.staging.digitalearthpacific.org)\n",
+    "to obtain these datasets, and apply it on a mineral resource detection downstream task\n",
+    "on two levels:\n",
+    "\n",
+    "1. Coarse level (chip of size 5.12km x 5.12km) - Using embeddings to get a general\n",
+    "semantic picture\n",
+    "2. Fine level (pixel of size 10m x 10m) - Using a fine-tuned decoder head to get\n",
+    "pixel-level segmentation masks\n",
+    "\n",
+    "References:\n",
+    "- https://github.com/digitalearthpacific/mineral-resource-detection\n",
+    "- https://github.com/Clay-foundation/model/discussions/140"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b0dbed2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pystac_client\n",
+    "import shapely\n",
+    "import stackstac\n",
+    "from rasterio.enums import Resampling\n",
+    "\n",
+    "BAND_GROUPS = {\n",
+    "    \"rgb\": [\"B04\", \"B03\", \"B02\"],\n",
+    "    \"rededge\": [\"B05\", \"B06\", \"B07\", \"B8A\"],\n",
+    "    \"nir\": [\"B08\"],\n",
+    "    \"swir\": [\"B11\", \"B12\"],\n",
+    "    \"sar\": [\"mean_vv\", \"mean_vh\"],\n",
+    "}\n",
+    "\n",
+    "STAC_API = \"https://stac.staging.digitalearthpacific.org\"\n",
+    "COLLECTION = \"dep_s2_geomad\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03fa77d3",
+   "metadata": {},
+   "source": [
+    "## Find Sentinel-2 and Sentinel-1 composites stored as Cloud-Optimized GeoTIFFs\n",
+    "\n",
+    "Define spatiotemporal query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a1ac2ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define area of interest\n",
+    "area_of_interest = shapely.box(xmin=177.2, ymin=-18.4, xmax=178.9, ymax=-17.2)\n",
+    "\n",
+    "# Define temporal range\n",
+    "daterange: dict = [\"2021-01-01T00:00:00Z\", \"2021-12-31T23:59:59Z\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba4e6aeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = pystac_client.Client.open(url=STAC_API)\n",
+    "\n",
+    "sen2_search = catalog.search(\n",
+    "    collections=[COLLECTION],\n",
+    "    datetime=daterange,\n",
+    "    intersects=area_of_interest,\n",
+    "    max_items=100,\n",
+    ")\n",
+    "\n",
+    "items = sen2_search.get_all_items()\n",
+    "\n",
+    "print(f\"Found {len(items)} items\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90d5183d",
+   "metadata": {},
+   "source": [
+    "## Download the data\n",
+    "Get the data into a numpy array and visualize the imagery. STAC browser URL is at\n",
+    "https://stac-browser.staging.digitalearthpacific.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cccf2b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract coordinate system from first item\n",
+    "epsg = items[0].properties[\"proj:epsg\"]\n",
+    "\n",
+    "# Convert point from lon/lat to UTM projection\n",
+    "poidf = gpd.GeoDataFrame(crs=\"OGC:CRS84\", geometry=[area_of_interest.centroid]).to_crs(\n",
+    "    epsg\n",
+    ")\n",
+    "geom = poidf.iloc[0].geometry\n",
+    "\n",
+    "# Create bounds of the correct size, the model\n",
+    "# requires 512x512 pixels at 10m resolution.\n",
+    "bounds = (geom.x - 2560, geom.y - 2560, geom.x + 2560, geom.y + 2560)\n",
+    "\n",
+    "# Retrieve the pixel values, for the bounding box in\n",
+    "# the target projection. In this example we use only\n",
+    "# the RGB and NIR band groups.\n",
+    "stack = stackstac.stack(\n",
+    "    items,\n",
+    "    bounds=bounds,\n",
+    "    snap_bounds=False,\n",
+    "    epsg=epsg,\n",
+    "    resolution=10,\n",
+    "    dtype=\"float32\",\n",
+    "    rescale=False,\n",
+    "    fill_value=0,\n",
+    "    assets=BAND_GROUPS[\"rgb\"] + BAND_GROUPS[\"nir\"],\n",
+    "    resampling=Resampling.nearest,\n",
+    ")\n",
+    "\n",
+    "stack = stack.compute()\n",
+    "assert stack.shape == (1, 4, 512, 512)\n",
+    "\n",
+    "stack.sel(band=[\"B04\", \"B03\", \"B02\"]).plot.imshow(\n",
+    "    row=\"time\", rgb=\"band\", vmin=0, vmax=2000\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorial_digital_earth_pacific.py
+++ b/docs/tutorial_digital_earth_pacific.py
@@ -1,0 +1,120 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Digital Earth Pacific mineral resource detection using Clay
+#
+# This notebook applies the Clay model on imagery composites, specifically a Sentinel-2
+# Geometric Median [(GeoMAD)](https://docs.digitalearthafrica.org/en/latest/data_specs/GeoMAD_specs.html)
+# and Sentinel-1 mean composite. We will use
+# [Digital Earth Pacific's STAC API](https://stac-browser.staging.digitalearthpacific.org)
+# to obtain these datasets, and apply it on a mineral resource detection downstream task
+# on two levels:
+#
+# 1. Coarse level (chip of size 5.12km x 5.12km) - Using embeddings to get a general
+# semantic picture
+# 2. Fine level (pixel of size 10m x 10m) - Using a fine-tuned decoder head to get
+# pixel-level segmentation masks
+#
+# References:
+# - https://github.com/digitalearthpacific/mineral-resource-detection
+# - https://github.com/Clay-foundation/model/discussions/140
+
+# %%
+
+import geopandas as gpd
+import pystac_client
+import shapely
+import stackstac
+from rasterio.enums import Resampling
+
+BAND_GROUPS = {
+    "rgb": ["B04", "B03", "B02"],
+    "rededge": ["B05", "B06", "B07", "B8A"],
+    "nir": ["B08"],
+    "swir": ["B11", "B12"],
+    "sar": ["mean_vv", "mean_vh"],
+}
+
+STAC_API = "https://stac.staging.digitalearthpacific.org"
+COLLECTION = "dep_s2_geomad"
+
+# %% [markdown]
+# ## Find Sentinel-2 and Sentinel-1 composites stored as Cloud-Optimized GeoTIFFs
+#
+# Define spatiotemporal query
+
+# %%
+# Define area of interest
+area_of_interest = shapely.box(xmin=177.2, ymin=-18.4, xmax=178.9, ymax=-17.2)
+
+# Define temporal range
+daterange: dict = ["2021-01-01T00:00:00Z", "2021-12-31T23:59:59Z"]
+
+# %%
+catalog = pystac_client.Client.open(url=STAC_API)
+
+sen2_search = catalog.search(
+    collections=[COLLECTION],
+    datetime=daterange,
+    intersects=area_of_interest,
+    max_items=100,
+)
+
+items = sen2_search.get_all_items()
+
+print(f"Found {len(items)} items")
+
+# %% [markdown]
+# ## Download the data
+# Get the data into a numpy array and visualize the imagery. STAC browser URL is at
+# https://stac-browser.staging.digitalearthpacific.org
+
+# %%
+# Extract coordinate system from first item
+epsg = items[0].properties["proj:epsg"]
+
+# Convert point from lon/lat to UTM projection
+poidf = gpd.GeoDataFrame(crs="OGC:CRS84", geometry=[area_of_interest.centroid]).to_crs(
+    epsg
+)
+geom = poidf.iloc[0].geometry
+
+# Create bounds of the correct size, the model
+# requires 512x512 pixels at 10m resolution.
+bounds = (geom.x - 2560, geom.y - 2560, geom.x + 2560, geom.y + 2560)
+
+# Retrieve the pixel values, for the bounding box in
+# the target projection. In this example we use only
+# the RGB and NIR band groups.
+stack = stackstac.stack(
+    items,
+    bounds=bounds,
+    snap_bounds=False,
+    epsg=epsg,
+    resolution=10,
+    dtype="float32",
+    rescale=False,
+    fill_value=0,
+    assets=BAND_GROUPS["rgb"] + BAND_GROUPS["nir"],
+    resampling=Resampling.nearest,
+)
+
+stack = stack.compute()
+assert stack.shape == (1, 4, 512, 512)
+
+stack.sel(band=["B04", "B03", "B02"]).plot.imshow(
+    row="time", rgb="band", vmin=0, vmax=2000
+)


### PR DESCRIPTION
Draft tutorial for Digital Earth Pacific. Using the STAC API at https://stac.staging.digitalearthpacific.org and looking at their Sentinel-2 GeoMAD and Sentinel-1 mean composite.

Note that I've used [`jupytext`](https://github.com/mwouts/jupytext) to pair the .ipynb notebook with a .py script to make it easier to review in-line. Will keep only one of those files before merging.

Towards https://github.com/Clay-foundation/model/discussions/140