### PR TITLE
Updating location to download imagery script in docs

### DIFF
--- a/docs/run_region.md
+++ b/docs/run_region.md
@@ -95,7 +95,7 @@ be downloaded for each MGRS tile.
 ```bash
 for i in {0..5}; do
 
-python scripts/datacube.py \
+python scripts/pipeline/datacube.py \
     --sample data/mgrs/mgrs_aoi.fgb \
     --localpath data/chips  \
     --index $i \


### PR DESCRIPTION
Noticed the bash script in `docs/run_region.md` didn't point to the correct location anymore so updating to [point to the new location of `datacube.py`](https://github.com/Clay-foundation/model/blob/main/scripts/pipeline/datacube.py)