### PR TITLE
Fix missing env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,11 @@ channels:
   - nodefaults
 dependencies:
   - conda-lock~=2.5.6
+  - boto3
   - einops~=0.7.0
   - fiona~=1.9.5
   - geopandas-base~=0.14.1
+  - geoarrow-pyarrow
   - h5netcdf~=1.3.0
   - jupyter-book~=1.0.0
   - jupyterlab~=4.0.7

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,12 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - boto3~=1.34.1
   - conda-lock~=2.5.6
-  - boto3
   - einops~=0.7.0
   - fiona~=1.9.5
   - geopandas-base~=0.14.1
-  - geoarrow-pyarrow
+  - geoarrow-pyarrow~=0.1.2
   - h5netcdf~=1.3.0
   - jupyter-book~=1.0.0
   - jupyterlab~=4.0.7


### PR DESCRIPTION
Hey friends! 
While testing locally, I noticed that the `environment.yml` file seems to be missing some packages for the notebooks in `/docs`. 
I've made my attempt at fixing the version numbers. 

I also noticed that this repo is missing a reference to the submodule [stacchip ](https://github.com/Clay-foundation/stacchip)

https://github.com/Clay-foundation/model/blob/a61f9faf4cadfdbef76b0651ae0aa638ef396323/docs/clay-v1-wall-to-wall.ipynb#L56

To get this to run locally, I had to copy and move the directory around for stacchip. 