### PR TITLE
Point latest release to v1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ The Clay model can be used in three main ways:
 - Our **website** is [madewithclay.org](https://madewithclay.org).
 - The Clay model **code** lives on [Github](https://github.com/Clay-foundation/model).
   License: [Apache-w.0](https://github.com/Clay-foundation/model/blob/main/LICENSE).
-  The latest release is [v0.0.1](https://github.com/Clay-foundation/model/releases/tag/v0.0.1)
+  The latest release is [v1.0](https://github.com/Clay-foundation/model/releases/tag/v1.0)
 - The Clay model **weights**  on [Hugging Face](https://huggingface.co/made-with-clay/Clay/).
   License: [OpenRAIL-M](https://github.com/Clay-foundation/model/blob/main/LICENSE-MODEL.md).
 - The Clay **documentation** [lives on this site](https://clay-foundation.github.io/model/index.html).


### PR DESCRIPTION
Hi,

Just a small error in the docs: The latest release being pointed to is wrong. 

This PR changes it so that the docs point to release v1.0 of the model instead of v.0.0.1


Let me know if you want me to add a line in the changelog, but it's such a trivial change that it might be too small to go in. 