### PR TITLE
Add pre-commit hook for codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+  - id: codespell
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.6.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.codespell]
+ignore-words-list = "linz"


### PR DESCRIPTION
Automate typo-finding using [codespell](https://github.com/codespell-project/codespell/tree/v2.3.0?tab=readme-ov-file#pre-commit-hook).

Added a `pyproject.toml` file with a `[tool.codespell]` section to configure a list of words to ignore (e.g. LINZ).