### PR TITLE
Document MODIS data sampling

### DIFF
--- a/configs/metadata.yaml
+++ b/configs/metadata.yaml
@@ -184,3 +184,38 @@ sentinel-1-rtc:
     wavelength:
       vv: 3.5
       vh: 4.0
+modis:
+  band_order:
+    - sur_refl_b01
+    - sur_refl_b02
+    - sur_refl_b03
+    - sur_refl_b04
+    - sur_refl_b05
+    - sur_refl_b06
+    - sur_refl_b07
+  gsd: 500
+  bands:
+    mean:
+      sur_refl_b01: 1072.471882
+      sur_refl_b02: 1624.482782
+      sur_refl_b03: 931.892947
+      sur_refl_b04: 1023.849436
+      sur_refl_b05: 1599.963956
+      sur_refl_b06: 1404.271537
+      sur_refl_b07: 1051.350204
+    std:
+      sur_refl_b01: 1643.113109
+      sur_refl_b02: 1878.537956
+      sur_refl_b03: 1449.024803
+      sur_refl_b04: 1538.677198
+      sur_refl_b05: 1763.359331
+      sur_refl_b06: 1618.157770
+      sur_refl_b07: 1396.227168
+    wavelength:
+      sur_refl_b01: 645.0
+      sur_refl_b02: 858.5
+      sur_refl_b03: 469.0
+      sur_refl_b04: 555.0
+      sur_refl_b05: 1240.0
+      sur_refl_b06: 1640.0
+      sur_refl_b07: 2130.0

--- a/docs/release-notes/data_sampling.md
+++ b/docs/release-notes/data_sampling.md
@@ -112,6 +112,67 @@ and a maximum of 2000 scenes for each catalog that was included.
 We selected the latest imagery for each of the available regions
 of new zealand. The list of catalogs is in the linz processor file.
 
+### MODIS sampling strategy
+
+For MODIS we used the [Surface Reflectance 8-Day (500m)](https://planetarycomputer.microsoft.com/dataset/modis-09A1-061)
+product. The data is distributed in SIN grid tiles. We included all SIN grid
+tiles that do not have any nodata inside. The selected SIN grid tiles are then
+transform to EPSG:3857 for all tiles. This results in some variation between the
+nominal resolution, although the original resolution from the SIN projection is
+500 meters. For input to the model, we assumed the 500m resolution as a fixed
+resolution size for all tiles.
+
+Algorithm to determine which tiles do not have nodata is shown in the code block
+below. This resulted in 233 SIN grid tiles to be selected. For each of these
+we sampled the first STAC search result for each month in each year from 2018
+until 2023. This therefore resulted in 72 (`6 years * 12 months`) separate scenes
+for each of the 233 SIN grid tiles.
+
+Script for selection of SIN grid tiles included in the sampling:
+
+```python
+from multiprocessing import Pool
+import rasterio
+import planetary_computer as pc
+import pystac_client
+import numpy as np
+
+SIN_GRID_TILES = []
+for i in SIN_VERTICAL_RANGE:
+    for j in SIN_HORIZONTAL_RANGE:
+        SIN_GRID_TILES.append((i, j))
+
+def evaluate_nodata(i, j):
+    catalog = pystac_client.Client.open(STAC_API, modifier=pc.sign_inplace)
+    items = catalog.search(
+        collections=[COLLECTION],
+        query={
+            "modis:vertical-tile": {
+                "eq": i,
+            },
+            "modis:horizontal-tile": {
+                "eq": j,
+            },
+        },
+        max_items=1,
+    )
+    item = list(items.item_collection())[0]
+
+    with rasterio.open(item.assets["sur_refl_b01"].href) as src:
+        data = src.read()
+
+    nodata = np.sum(data == -28672)
+
+    if nodata == 0:
+        print(i, j)
+        return i, j
+
+if __name__ == '__main__':
+    with Pool(16) as p:
+        indexes = p.starmap(evaluate_nodata, SIN_GRID_TILES)
+    print("done")
+    print(indexes)
+```
 
 ## Data preparation
 
@@ -136,6 +197,7 @@ Using stacchip, we created a dataset with a size of 33.8 TB of imagery, with abo
 | Landsat-c2l1    | 5827333 |
 | Landsat-c2l2-sr | 5790651 |
 | Sentinel-1-rtc | 16133394 |
+| MODIS          |  1350864 |
 
 # Older versions
 


### PR DESCRIPTION
Added Modis to our training data set using stacchip.

- Chip dates and locations data added to general index using the new [modis processor](https://github.com/Clay-foundation/stacchip/blob/main/stacchip/processors/modis_processor.py) in stacchip
- All data prechipped using the slightly adapted [prechp module](https://github.com/Clay-foundation/stacchip/blob/main/stacchip/processors/prechip.py)
- Stats computed using 10% of the data through the almost unchanged [stats module](https://github.com/Clay-foundation/stacchip/blob/main/stacchip/processors/stats.py)

Most of the work went into finding a reasonable projection for the data, which comes in SIN grid originally. The processor reprojects the modis tiles into web mercator. The prechipping and stats were working almost out of the box 🚀 .