### PR TITLE
Added Planetscope SR mapping

### DIFF
--- a/configs/metadata.yaml
+++ b/configs/metadata.yaml
@@ -49,6 +49,49 @@ sentinel-2-l2a:
       nir08: 0.865
       swir16: 1.61
       swir22: 2.19
+planetscope-sr:
+  band_order:
+    - coastal_blue
+    - blue
+    - green_i
+    - green
+    - yellow
+    - red
+    - rededge
+    - nir
+  rgb_indices:
+    - 5
+    - 3
+    - 1
+  gsd: 5
+  bands:
+    mean:
+      coastal_blue: 1720.
+      blue: 1715.
+      green_i: 1913.
+      green: 2088.
+      yellow: 2274.
+      red: 2290.
+      rededge: 2613.
+      nir: 3970.
+    std:
+      coastal_blue: 747.
+      blue: 698.
+      green_i: 739.
+      green: 768.
+      yellow: 849.
+      red: 868.
+      rededge: 849.
+      nir: 914.
+    wavelength:
+      coastal_blue: 0.443
+      blue: 0.490
+      green_i: 0.531
+      green: 0.565
+      yellow: 0.610
+      red: 0.665
+      rededge: 0.705
+      nir: 0.865
 landsat-c2l1:
   band_order:
     - red


### PR DESCRIPTION
This adds mappings for the 8-band Planetscope Surface Reflectance product. 

The statistics were calculated using the openly (CC-BY-NC) available [Planet Sandox data](https://collections.sentinel-hub.com/planet-sandbox-data/). 

Due to the available data in Planet Sandox, water and arid regions are underrepresented in the sample. This might skew the results slightly (i.e. lower std than if it was a truly random global sample). 