### PR TITLE
Correct LINZ resolution in metadata

### DIFF
--- a/configs/metadata.yaml
+++ b/configs/metadata.yaml
@@ -198,7 +198,7 @@ linz:
     - 0
     - 1
     - 2
-  gsd: 0.5
+  gsd: 0.05
   bands:
     mean:
       red: 89.96


### PR DESCRIPTION
A quick bump to the instrument config for LINZ, which has a 5cm resolution, not 50cm.