### PR TITLE
Fix deprecated version of `actions/upload-artifact: v3`

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Upload the built HTML to GitHub Artifacts
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_build/html
 
@@ -78,4 +78,4 @@ jobs:
       # Push the book's HTML to github-pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Trying to fix  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

by pinning V2