### PR TITLE
3 bug fixes in tutorial wall-to-wall.ipynb

### DIFF
--- a/docs/tutorials/wall-to-wall.ipynb
+++ b/docs/tutorials/wall-to-wall.ipynb
@@ -171,7 +171,7 @@
    "outputs": [],
    "source": [
     "# Extract coordinate system from first item\n",
-    "epsg = items[0].properties[\"proj:epsg\"]\n",
+    "epsg = int(items[0].properties[\"proj:code\"].replace(\"EPSG:\", \"\"))\n",
     "\n",
     "# Convert point of interest into the image projection\n",
     "# (assumes all images are in the same projection)\n",

--- a/docs/tutorials/wall-to-wall.ipynb
+++ b/docs/tutorials/wall-to-wall.ipynb
@@ -256,7 +256,7 @@
     "    snap_bounds=False,\n",
     "    epsg=epsg,\n",
     "    resolution=gsd,\n",
-    "    dtype=\"float32\",\n",
+    "    dtype=\"float64\",\n",
     "    rescale=False,\n",
     "    fill_value=0,\n",
     "    assets=[\"blue\", \"green\", \"red\", \"nir\"],\n",

--- a/docs/tutorials/wall-to-wall.ipynb
+++ b/docs/tutorials/wall-to-wall.ipynb
@@ -139,7 +139,7 @@
     "    query={\"eo:cloud_cover\": {\"lt\": 80}},\n",
     ")\n",
     "\n",
-    "all_items = search.get_all_items()\n",
+    "all_items = search.item_collection()\n",
     "\n",
     "# Reduce to one per date (there might be some duplicates\n",
     "# based on the location)\n",


### PR DESCRIPTION
This PR fixes 3 issues in the tutorial wall-to-wall.ipynb

Replace deprecated search.get_all_items() with search.item_collection()

1. Extract epsg from `proj:code` property, as `proj:epsg` has been deprecated
2. Fix error `The fill_value 0 is incompatible with the output dtype float32`
3. Issues 2 and 3 are blockers and prevent from running the notebook.

### proj:epsg field deprecation
Deprecation is explained in the Projection Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification: https://github.com/stac-extensions/projection

> The field proj:epsg has been deprecated in v1.2.0 in favor of proj:code and has been removed in v2.0.0. For example, the former field "proj:epsg": 32659 must be migrated to "proj:code": "EPSG:32659".